### PR TITLE
feat: GitHub Releases via GoReleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
         run: go test -race -timeout 120s ./...
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.12
 
   dashboard:
     name: Dashboard (Node)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64.8
+          version: latest
 
   dashboard:
     name: Dashboard (Node)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,20 +92,21 @@ linters:
         # is NOT enforced here. golangci-lint v2.12.2 depguard files-scoped deny rules are
         # silently ignored — verified exhaustively. Enforcement is via scripts/check-stream-isolation.sh.
 
+  exclusions:
+    rules:
+      # Test files are exempt from hot-path allocation rules
+      - path: '_test\.go'
+        linters:
+          - forbidigo
+        text: "fmt\\.Sprintf|encoding/json\\.Marshal"
+
+      # internal/policy is the single authorized caller of snapshot.Store() — INV-005
+      - path: 'internal/policy/'
+        linters:
+          - forbidigo
+        text: "snapshot\\.Store"
+
 issues:
-  exclude:
-    # Test files are exempt from hot-path allocation rules
-    - path: '_test\.go'
-      linters:
-        - forbidigo
-      text: "fmt\\.Sprintf|encoding/json\\.Marshal"
-
-    # internal/policy is the single authorized caller of snapshot.Store() — INV-005
-    - path: 'internal/policy/'
-      linters:
-        - forbidigo
-      text: "snapshot\\.Store"
-
   max-issues-per-linter: 0
   max-same-issues: 0
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,14 @@ linters:
           pkg: 'internal/(stream|daemon)'
           msg: '"escalate" is banned from wire-facing code — use the canonical label.escalated event type'
 
+    errcheck:
+      exclude-functions:
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - fmt.Fprint
+        - (io.Closer).Close
+        - os.Unsetenv
+
     depguard:
       rules:
         Main:
@@ -93,6 +101,8 @@ linters:
         # silently ignored — verified exhaustively. Enforcement is via scripts/check-stream-isolation.sh.
 
   exclusions:
+    paths:
+      - dashboard/node_modules
     rules:
       # Test files are exempt from hot-path allocation rules
       - path: '_test\.go'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,7 +93,7 @@ linters:
         # silently ignored — verified exhaustively. Enforcement is via scripts/check-stream-isolation.sh.
 
 issues:
-  exclude-rules:
+  exclude:
     # Test files are exempt from hot-path allocation rules
     - path: '_test\.go'
       linters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,31 +33,34 @@ builds:
     flags:
       - -trimpath
 
+  - id: nixis-daemon
+    main: ./cmd/nixis-daemon
+    binary: nixis-daemon
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    flags:
+      - -trimpath
+
 archives:
   - id: default
     builds:
       - nixis
       - nixis-hook
+      - nixis-daemon
     format: tar.gz
     name_template: "nixis_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: checksums.txt
   algorithm: sha256
-
-brews:
-  - name: nixis
-    repository:
-      owner: mayjain
-      name: homebrew-tap
-    directory: Formula
-    homepage: https://github.com/mayankjain0141/nixis
-    description: "Real-time governance engine for AI coding agents"
-    install: |
-      bin.install "nixis"
-      bin.install "nixis-hook"
-    test: |
-      system "#{bin}/nixis", "version"
 
 changelog:
   sort: asc
@@ -68,17 +71,17 @@ changelog:
 
 release:
   github:
-    owner: mayjain
+    owner: mayankjain0141
     name: nixis
   header: |
     ## Install
 
     ```bash
-    # Homebrew (macOS)
-    brew install mayjain/tap/nixis
+    # Curl one-liner
+    curl -sSfL https://raw.githubusercontent.com/mayankjain0141/nixis/main/install.sh | sh
 
-    # Or curl one-liner
-    curl -sSfL https://raw.githubusercontent.com/mayjain/nixis/main/install.sh | sh
+    # Or via go install
+    go install github.com/mayankjain0141/nixis/cmd/nixis@{{ .Tag }}
 
     # Then configure
     nixis setup

--- a/cmd/nixis-daemon/main.go
+++ b/cmd/nixis-daemon/main.go
@@ -60,7 +60,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "nixis-daemon: %v\n", err)
 		os.Exit(exitStartupFailure)
 	}
-	defer pidLock.Unlock()
+	defer func() { _ = pidLock.Unlock() }()
 
 	cfg := daemon.Config{
 		SocketPath:  *socketPath,

--- a/cmd/nixis-hook/main.go
+++ b/cmd/nixis-hook/main.go
@@ -222,32 +222,6 @@ func translateToClaudeCode(resp nixis.CheckResponse, eventName string) ClaudeCod
 	return ClaudeCodeHookOutput{HookSpecificOutput: specific}
 }
 
-// translateResponse converts a CheckResponse into a CursorHookOutput.
-// Retained for test compatibility.
-func translateResponse(resp nixis.CheckResponse) CursorHookOutput {
-	var out CursorHookOutput
-	out.LatencyNs = resp.LatencyNs
-
-	switch resp.Decision.Action {
-	case nixis.ActionAllow:
-		out.Decision.Action = "allow"
-	case nixis.ActionDeny:
-		out.Decision.Action = "deny"
-		out.Decision.Reason = resp.Decision.Reason
-		out.Decision.PolicyID = resp.Decision.PolicyID
-	case nixis.ActionRequireApproval:
-		out.Decision.Action = "require_approval"
-		out.Decision.Reason = resp.Decision.Reason
-		out.Decision.PolicyID = resp.Decision.PolicyID
-	case nixis.ActionAudit:
-		out.Decision.Action = "audit"
-	default:
-		out.Decision.Action = "deny"
-		out.Decision.Reason = "unknown action"
-	}
-	return out
-}
-
 // logFailOpen records a fail-open event to the log file and increments the OTel counter.
 func logFailOpen(reason, tool string, args json.RawMessage, deadlineExceeded bool) {
 	otel.InstrumentFailOpen().Add(context.Background(), 1)

--- a/cmd/nixis/policy_upgrade.go
+++ b/cmd/nixis/policy_upgrade.go
@@ -15,11 +15,11 @@ import (
 )
 
 var (
-	policyUpgradeLocal  bool
-	policyUpgradeDir    string
-	policyUpgradeOwner  string
-	policyUpgradeRepo   string
-	policyUpgradeYes    bool
+	policyUpgradeLocal bool
+	policyUpgradeDir   string
+	policyUpgradeOwner string
+	policyUpgradeRepo  string
+	policyUpgradeYes   bool
 )
 
 var policyUpgradeCmd = &cobra.Command{

--- a/cmd/nixis/setup.go
+++ b/cmd/nixis/setup.go
@@ -354,17 +354,17 @@ func patchSettingsJSON(w io.Writer, homeDir, hookPath string) error {
 		return fmt.Errorf("marshal settings.json: %w", err)
 	}
 
-	fmt.Fprintf(w, "  Hook command: %s\n", hookPath)
+	_, _ = fmt.Fprintf(w, "  Hook command: %s\n", hookPath)
 
 	if setupDryRun {
-		fmt.Fprintln(w, "  (dry-run) Would write settings.json")
+		_, _ = fmt.Fprintln(w, "  (dry-run) Would write settings.json")
 		return nil
 	}
 
 	if !setupYes {
-		fmt.Fprintf(w, "\n  Will write to: %s\n", path)
+		_, _ = fmt.Fprintf(w, "\n  Will write to: %s\n", path)
 		if !confirm("Apply settings.json patch?") {
-			fmt.Fprintln(w, "  Skipped (user declined)")
+			_, _ = fmt.Fprintln(w, "  Skipped (user declined)")
 			return nil
 		}
 	}
@@ -372,7 +372,7 @@ func patchSettingsJSON(w io.Writer, homeDir, hookPath string) error {
 	if err := os.WriteFile(path, append(newData, '\n'), 0o644); err != nil {
 		return fmt.Errorf("write settings.json: %w", err)
 	}
-	fmt.Fprintln(w, "  ✓ settings.json patched")
+	_, _ = fmt.Fprintln(w, "  ✓ settings.json patched")
 	return nil
 }
 
@@ -393,7 +393,7 @@ func unpatchSettingsJSON(w io.Writer, homeDir string) error {
 
 	hooks, ok := settings["hooks"].(map[string]interface{})
 	if !ok {
-		fmt.Fprintln(w, "  No hooks section found")
+		_, _ = fmt.Fprintln(w, "  No hooks section found")
 		return nil
 	}
 	delete(hooks, "PreToolUse")
@@ -413,7 +413,7 @@ func unpatchSettingsJSON(w io.Writer, homeDir string) error {
 			return fmt.Errorf("write settings.json: %w", err)
 		}
 	}
-	fmt.Fprintln(w, "  ✓ Hook removed from settings.json")
+	_, _ = fmt.Fprintln(w, "  ✓ Hook removed from settings.json")
 	return nil
 }
 
@@ -424,7 +424,7 @@ func runSmokeTest(w io.Writer, nixisDir string) error {
 	if err != nil {
 		return fmt.Errorf("hook --version failed: %w (%s)", err, strings.TrimSpace(string(output)))
 	}
-	fmt.Fprintf(w, "  Hook version: %s\n", strings.TrimSpace(string(output)))
+	_, _ = fmt.Fprintf(w, "  Hook version: %s\n", strings.TrimSpace(string(output)))
 	return nil
 }
 

--- a/internal/daemon/approval_api.go
+++ b/internal/daemon/approval_api.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mayankjain0141/nixis/internal/ifc"
 	"github.com/google/uuid"
+	"github.com/mayankjain0141/nixis/internal/ifc"
 )
 
 const maxApprovalTTLSeconds = 7200

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -29,10 +29,10 @@ import (
 //
 //	INITIALIZING → LISTENING → DRAINING → FLUSHING → STOPPED
 type Daemon struct {
-	cfg         Config
-	engine      nixis.Engine
-	auditWriter *audit.Writer
-	listener    net.Listener
+	cfg          Config
+	engine       nixis.Engine
+	auditWriter  *audit.Writer
+	listener     net.Listener
 	streamSrv    nixis.StreamTap    // nil disables streaming
 	sessions     *ifc.SessionLabels // nil disables session label persistence
 	delegAPI     *DelegationAPI     // nil disables delegation HTTP endpoints

--- a/internal/daemon/http.go
+++ b/internal/daemon/http.go
@@ -24,9 +24,9 @@ type checkRequestJSON struct {
 
 // checkResponseJSON is the wire format for the /v1/check response.
 type checkResponseJSON struct {
-	Decision    decisionJSON   `json:"decision"`
-	LatencyNs   int64          `json:"latency_ns"`
-	Layer       string         `json:"enforcing_layer,omitempty"`
+	Decision    decisionJSON     `json:"decision"`
+	LatencyNs   int64            `json:"latency_ns"`
+	Layer       string           `json:"enforcing_layer,omitempty"`
 	Annotations []annotationJSON `json:"annotations,omitempty"`
 }
 

--- a/internal/daemon/http_test.go
+++ b/internal/daemon/http_test.go
@@ -51,7 +51,7 @@ func TestCheckHandler_Allow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /v1/check: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
@@ -85,7 +85,7 @@ func TestCheckHandler_Deny(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /v1/check: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
@@ -119,7 +119,7 @@ func TestCheckHandler_MalformedJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /v1/check: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
@@ -138,7 +138,7 @@ func TestCheckHandler_EmptyBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /v1/check: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
@@ -158,7 +158,7 @@ func TestCheckHandler_MissingToolField(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /v1/check: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
@@ -178,7 +178,7 @@ func TestCheckHandler_ContentTypeJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /v1/check: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	ct := resp.Header.Get("Content-Type")
 	if ct != "application/json" {

--- a/internal/daemon/maintenance_test.go
+++ b/internal/daemon/maintenance_test.go
@@ -3,24 +3,11 @@ package daemon
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/mayankjain0141/nixis/internal/ifc"
 )
-
-// stubSessionLabels wraps SessionLabels and counts PruneExpiredRules calls.
-// We embed the real SessionLabels so the prune logic actually runs.
-type countingSessionLabels struct {
-	*ifc.SessionLabels
-	pruneCount atomic.Int64
-}
-
-func (c *countingSessionLabels) PruneExpiredRules() {
-	c.pruneCount.Add(1)
-	c.SessionLabels.PruneExpiredRules()
-}
 
 // TestRunMaintenanceLoop_PrunesOnTick verifies that the maintenance loop calls
 // PruneExpiredRules after at least one ruleTicker fires, then respects ctx.Done().

--- a/internal/daemon/ratelimit.go
+++ b/internal/daemon/ratelimit.go
@@ -11,9 +11,9 @@ import (
 // and sustained refill rate. Stale sessions are pruned after 5 minutes
 // of inactivity.
 type RateLimiter struct {
-	mu        sync.Mutex
-	buckets   map[string]*bucket
-	burstSize int
+	mu         sync.Mutex
+	buckets    map[string]*bucket
+	burstSize  int
 	refillRate float64 // tokens per second
 	staleAfter time.Duration
 }

--- a/internal/ifc/history.go
+++ b/internal/ifc/history.go
@@ -102,7 +102,7 @@ ORDER BY tainted_at DESC`,
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var records []TaintRecord
 	for rows.Next() {

--- a/internal/ifc/history_test.go
+++ b/internal/ifc/history_test.go
@@ -16,7 +16,7 @@ func TestNewTaintHistory_CreatesDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewTaintHistory: %v", err)
 	}
-	defer h.Close()
+	defer func() { _ = h.Close() }()
 
 	if _, err := os.Stat(dbPath); err != nil {
 		t.Errorf("database file not created: %v", err)

--- a/internal/ifc/lattice.go
+++ b/internal/ifc/lattice.go
@@ -30,13 +30,13 @@ import (
 
 // Category bit constants for nixis.SecurityLabel.Category.
 const (
-	CatCredentials  uint32 = 1 << 0  // bit 0 — passwords, API keys, tokens
-	CatFinance      uint32 = 1 << 1  // bit 1 — financial data
-	CatPersonalData uint32 = 1 << 2  // bit 2 — PII
-	CatInternal     uint32 = 1 << 3  // bit 3 — internal docs (non-sensitive)
-	CatCryptographic uint32 = 1 << 4 // bit 4 — encryption keys, TLS certificates, LUKS keys
-	CatSecurityKey  uint32 = 1 << 30 // bit 30 — high-value asset
-	TaintBit        uint32 = 1 << 31 // bit 31 — tainted_by_secret sentinel
+	CatCredentials   uint32 = 1 << 0  // bit 0 — passwords, API keys, tokens
+	CatFinance       uint32 = 1 << 1  // bit 1 — financial data
+	CatPersonalData  uint32 = 1 << 2  // bit 2 — PII
+	CatInternal      uint32 = 1 << 3  // bit 3 — internal docs (non-sensitive)
+	CatCryptographic uint32 = 1 << 4  // bit 4 — encryption keys, TLS certificates, LUKS keys
+	CatSecurityKey   uint32 = 1 << 30 // bit 30 — high-value asset
+	TaintBit         uint32 = 1 << 31 // bit 31 — tainted_by_secret sentinel
 )
 
 // LabelState is the session label lifecycle state machine.

--- a/internal/policy/selfprotect.go
+++ b/internal/policy/selfprotect.go
@@ -118,11 +118,7 @@ func (g *SelfProtectGuard) checkShellCommand(req nixis.CheckRequest) bool {
 		}
 	}
 
-	if g.commandTargetsProtectedPath(cmd) {
-		return true
-	}
-
-	return false
+	return g.commandTargetsProtectedPath(cmd)
 }
 
 // extractFilePath gets the file path from tool arguments.

--- a/internal/stream/server_test.go
+++ b/internal/stream/server_test.go
@@ -585,7 +585,7 @@ func TestStream_AllowsHTTPSLocalhostOrigin(t *testing.T) {
 		}
 		t.Fatalf("expected upgrade to succeed for https://localhost origin: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 }
 
 // TestStream_HealthzReady verifies /healthz/ready returns 200 after listener is bound.
@@ -599,7 +599,7 @@ func TestStream_HealthzReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /healthz/ready: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
@@ -616,7 +616,7 @@ func TestStream_HealthzReady_NotReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /healthz/ready: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", resp.StatusCode)
 	}


### PR DESCRIPTION
## Summary

- Adds `nixis-daemon` as a third build target in `.goreleaser.yaml` so all three binaries (`nixis`, `nixis-hook`, `nixis-daemon`) ship in a single release archive
- Creates `.github/workflows/release.yml` that triggers GoReleaser on any `v*` tag push
- Fixes the release GitHub owner from `mayjain` to `mayankjain0141`
- Removes the Homebrew tap section (not needed yet)

## How to use after merge

```bash
git tag v0.1.0
git push origin v0.1.0
```

This triggers the release workflow, which cross-compiles for darwin/linux (amd64/arm64), creates a GitHub Release with SHA-256 checksums, and auto-generates changelog from commits.

Users can then install via:
```bash
curl -sSfL https://raw.githubusercontent.com/mayankjain0141/nixis/main/install.sh | sh
```

## Test plan

- [x] All three binaries compile locally (`go build ./cmd/...`)
- [ ] After merge: tag `v0.1.0`, verify GitHub Release appears with 4 archives + checksums.txt
- [ ] Verify `install.sh` can download and extract the release