### PR TITLE
fix(ci): disable go cache, fix gRPC readiness race, add ci-complete gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Build
         run: go build ./...
@@ -58,3 +58,17 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  ci-complete:
+    name: CI complete
+    runs-on: ubuntu-latest
+    needs: [backend, dashboard]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [ "${{ needs.backend.result }}" != "success" ] || [ "${{ needs.dashboard.result }}" != "success" ]; then
+            echo "backend: ${{ needs.backend.result }}"
+            echo "dashboard: ${{ needs.dashboard.result }}"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -236,6 +236,19 @@ Nixis ships with a 784-case adversarial benchmark (`eval/`) covering 7 attack ca
 
 See [CONTRIBUTING.md](.github/CONTRIBUTING.md). Prerequisites: Go 1.25+, Node 20+.
 
+## Attributions
+
+The policies in `policies/imported/` are converted from third-party rule sets. Nixis does not claim authorship of the underlying detection logic — credit belongs to the original projects.
+
+| Source | License | What was imported |
+|--------|---------|-------------------|
+| [falcosecurity/rules](https://github.com/falcosecurity/rules) | Apache-2.0 | Runtime security rules (container escapes, reverse shells, credential access, privilege escalation) |
+| [kyverno/policies](https://github.com/kyverno/policies) | Apache-2.0 | Kubernetes admission policies (converted to CEL via `nixis policy import --llm-assist`) |
+| [open-policy-agent/gatekeeper-library](https://github.com/open-policy-agent/gatekeeper-library) | Apache-2.0 | OPA Gatekeeper constraint templates (converted to CEL) |
+| [agentwall/agentwall](https://github.com/agentwall/agentwall) | Apache-2.0 | AI agent tool-call constraints — Aravind, A. (2026). [AgentWall: A Runtime Safety Layer for Local AI Agents](https://arxiv.org/abs/2605.16265). arXiv:2605.16265 |
+
+The `policies/builtin/` rules and the 385-entry tool catalog (`pkg/adapters/catalog.json`) are original work.
+
 ## License
 
 [MIT](LICENSE) — Mayank Jain, 2026.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/mayankjain0141/nixis/actions/workflows/ci.yml/badge.svg)](https://github.com/mayankjain0141/nixis/actions/workflows/ci.yml)
 [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Medium](https://img.shields.io/badge/Medium-Blog-black?logo=medium)](https://medium.com/@mayankjain0141/building-an-ai-agent-firewall-lessons-from-three-rewrites-4120fe8af402)
 
 **Real-time governance engine for AI coding agents.** Built for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Works with any agent that exposes tool calls.
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -415,26 +415,22 @@ func TestIntegration_GRPCExtAuthz(t *testing.T) {
 		srvDone <- grpcSrv.Start(ctx)
 	}()
 
-	// Poll until the gRPC TCP port is reachable.
-	var conn *grpc.ClientConn
+	// Poll until the gRPC TCP port is reachable via actual TCP probe.
 	pollUntil(t, 3*time.Second, func() bool {
-		c, dialErr := grpc.NewClient(grpcAddr,
-			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		c, dialErr := net.DialTimeout("tcp", grpcAddr, 50*time.Millisecond)
 		if dialErr != nil {
 			return false
 		}
-		conn = c
+		_ = c.Close()
 		return true
 	}, "gRPC server did not become reachable within 3s")
-	defer func() { _ = conn.Close() }()
 
-	// nc -z equivalent: verify TCP port is open.
-	tcpConn, err := net.DialTimeout("tcp", grpcAddr, 1*time.Second)
+	conn, err := grpc.NewClient(grpcAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Errorf("TCP port %s not reachable: %v", grpcAddr, err)
-	} else {
-		_ = tcpConn.Close()
+		t.Fatalf("grpc.NewClient: %v", err)
 	}
+	defer func() { _ = conn.Close() }()
 
 	client := authv3.NewAuthorizationClient(conn)
 


### PR DESCRIPTION
## Summary

Three fixes in one:

- **`cache: false` on `setup-go`** — Go 1.26 toolchain caching causes tar extraction conflicts (`File exists`) on Ubuntu runners; disabling the cache unblocks the backend job
- **`TestIntegration_GRPCExtAuthz` readiness race** — `grpc.NewClient` is lazy (never fails), so `pollUntil` exited immediately before the server was listening; changed the poll condition to `net.DialTimeout` which actually probes TCP, then creates the gRPC client after confirming the port is open
- **`ci-complete` gate job** — single required check for branch protection; `needs: [backend, dashboard]` with `if: always()` so it runs and fails on docs-only PRs too, without needing to list every job in branch protection settings

## Test plan
- [ ] CI passes on this PR (all three jobs: backend, dashboard, ci-complete)
- [ ] Set `CI complete` as the required status check in branch protection (replaces individual job checks)