### PR TITLE
fix(installer): idempotent install, ETXTBSY fix, reload/uninstall, zombie process fix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,6 +57,10 @@ archives:
       - nixis-daemon
     format: tar.gz
     name_template: "nixis_{{ .Os }}_{{ .Arch }}"
+    files:
+      - src: policies/builtin/**
+        dst: policies/builtin
+        strip_parent: true
 
 checksum:
   name_template: checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,8 +58,8 @@ archives:
     format: tar.gz
     name_template: "nixis_{{ .Os }}_{{ .Arch }}"
     files:
-      - src: policies/builtin/**
-        dst: policies/builtin
+      - src: policies/**
+        dst: policies
         strip_parent: true
 
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build generate test-keys dev lint test install uninstall release-local clean dev-install update-policies preflight preflight-node
+.PHONY: build generate test-keys dev lint test install uninstall release-local clean dev-install update-policies preflight preflight-node ci install-hooks
 
 GO_MIN_VERSION := 1.25
 NODE_MIN_VERSION := 26
@@ -104,3 +104,23 @@ uninstall:
 ## release-local: build release artifacts locally (for testing)
 release-local:
 	goreleaser release --snapshot --clean
+
+## ci: run the same checks as GitHub CI (backend + dashboard)
+ci: preflight preflight-node
+	@echo "==> Backend: build"
+	@go build ./...
+	@echo "==> Backend: test"
+	@go test -race -timeout 120s ./...
+	@echo "==> Backend: lint"
+	@golangci-lint run ./...
+	@echo "==> Dashboard: type-check + test + build"
+	@cd dashboard && npm ci && npm run type-check && npm run test && npm run build
+	@echo ""
+	@echo "✓ All CI checks passed."
+
+## install-hooks: install git pre-push hook to run CI before every push
+install-hooks:
+	@echo "==> Installing git pre-push hook..."
+	@cp scripts/pre-push .git/hooks/pre-push
+	@chmod +x .git/hooks/pre-push
+	@echo "  ✓ Pre-push hook installed. 'make ci' will run before every push."

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,36 @@
-.PHONY: build generate test-keys dev lint test install uninstall release-local clean
+.PHONY: build generate test-keys dev lint test install uninstall release-local clean dev-install update-policies preflight preflight-node
+
+GO_MIN_VERSION := 1.25
+NODE_MIN_VERSION := 26
+
+## preflight: verify toolchain versions and environment before building
+preflight:
+	@if [ "$$(id -u)" = "0" ] && [ "$$NIXIS_ALLOW_ROOT" != "1" ]; then \
+	  echo "ERROR: Do not run 'make install' as root. It installs to ~/.nixis/ (your user dir)."; \
+	  echo "       If you really mean it, set NIXIS_ALLOW_ROOT=1"; exit 1; \
+	fi
+	@go_ver=$$(go version 2>/dev/null | grep -oE 'go[0-9]+\.[0-9]+' | sed 's/go//'); \
+	 if [ -z "$$go_ver" ]; then \
+	   echo "ERROR: Go not found. Install Go >= $(GO_MIN_VERSION): https://go.dev/dl/"; exit 1; \
+	 fi; \
+	 major=$$(echo $$go_ver | cut -d. -f1); minor=$$(echo $$go_ver | cut -d. -f2); \
+	 req_major=$$(echo $(GO_MIN_VERSION) | cut -d. -f1); req_minor=$$(echo $(GO_MIN_VERSION) | cut -d. -f2); \
+	 if [ "$$major" -lt "$$req_major" ] || { [ "$$major" -eq "$$req_major" ] && [ "$$minor" -lt "$$req_minor" ]; }; then \
+	   echo "ERROR: Go >= $(GO_MIN_VERSION) required (found $$go_ver). Install: https://go.dev/dl/"; exit 1; \
+	 fi
+
+## preflight-node: verify Node version (only for dashboard targets)
+preflight-node:
+	@node_ver=$$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1); \
+	 if [ -z "$$node_ver" ]; then \
+	   echo "ERROR: Node.js not found. Install Node >= $(NODE_MIN_VERSION): nvm install $(NODE_MIN_VERSION)"; exit 1; \
+	 fi; \
+	 if [ "$$node_ver" -lt "$(NODE_MIN_VERSION)" ]; then \
+	   echo "ERROR: Node >= $(NODE_MIN_VERSION) required (found v$$(node --version)). Run: nvm install $(NODE_MIN_VERSION)"; exit 1; \
+	 fi
 
 ## build: compile all Go binaries into bin/
-build:
+build: preflight
 	go build -o bin/ ./cmd/...
 
 ## clean: remove build artifacts and stale binaries
@@ -28,23 +57,49 @@ test:
 	go test ./... -race -count=1
 
 ## dev: start daemon + dashboard dev server (requires daemon binary built first)
-dev:
+dev: preflight preflight-node
 	@echo "Starting daemon on :9090..."
 	@go build -o /tmp/nixis-daemon ./cmd/nixis-daemon/ && \
 	  /tmp/nixis-daemon -policy-dir ./policies &
 	@echo "Starting dashboard dev server..."
 	@cd dashboard && npm run dev
 
-## install: build from source and run interactive setup
+## install: one-command build + deploy + restart (idempotent)
 install: build
-	@go build -o ~/.nixis/nixis ./cmd/nixis
-	@go build -o ~/.nixis/nixis-hook -ldflags="-s -w" ./cmd/nixis-hook
-	@~/.nixis/nixis setup
+	@echo "==> Stopping existing daemon (if running)..."
+	@(launchctl bootout gui/$$(id -u)/com.nixis.daemon 2>/dev/null || \
+	  systemctl --user stop nixis-daemon 2>/dev/null || true) && sleep 1
+	@echo "==> Deploying binaries..."
+	@mkdir -p ~/.nixis
+	@rm -f ~/.nixis/nixis ~/.nixis/nixis-hook ~/.nixis/nixis-daemon
+	@cp bin/nixis bin/nixis-hook bin/nixis-daemon ~/.nixis/
+	@chmod +x ~/.nixis/nixis ~/.nixis/nixis-hook ~/.nixis/nixis-daemon
+	@echo "==> Running setup (policies + service + hook)..."
+	@~/.nixis/nixis setup --yes --skip-binaries --policy-dir ./policies
 
-## uninstall: remove nixis installation
+## dev-install: full fresh setup (test-keys + dashboard deps + build + install)
+dev-install: preflight preflight-node
+	@echo "==> Full development setup..."
+	@test -f testdata/bundle_signing_key.pem || $(MAKE) test-keys
+	@cd dashboard && npm install
+	@$(MAKE) install
+
+## update-policies: refresh policies without rebuilding binaries
+update-policies:
+	@echo "==> Syncing policies to ~/.nixis/policies/..."
+	@mkdir -p ~/.nixis/policies
+	@rsync -a --delete ./policies/ ~/.nixis/policies/
+	@sleep 0.2
+	@~/.nixis/nixis reload 2>/dev/null || echo "Daemon not running; policies synced to disk."
+
+## uninstall: completely remove nixis
 uninstall:
-	@~/.nixis/nixis setup --uninstall --yes || true
-	@echo "Nixis uninstalled"
+	@~/.nixis/nixis uninstall --yes 2>/dev/null || \
+	  (echo "Nixis binary not found or hung. Manual cleanup:" && \
+	   echo "  pgrep -f nixis-daemon | xargs kill -9 2>/dev/null" && \
+	   echo "  rm -f ~/Library/LaunchAgents/com.nixis.daemon.plist" && \
+	   echo "  rm -rf ~/.nixis && rm -f /tmp/nixis.sock" && \
+	   echo "  Remove '# Nixis' block from your shell rc file")
 
 ## release-local: build release artifacts locally (for testing)
 release-local:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ That's it. Every tool call your agent makes is now evaluated against 44 security
 
 **Currently supported:** Claude Code (via PreToolUse hook). Cursor and other MCP-based agents work via the gRPC ext_authz or HTTP API integration.
 
+## Uninstall
+
+```bash
+nixis setup --uninstall -y
+```
+
+This stops the daemon service, removes the PreToolUse hook from `~/.claude/settings.json`, and deletes `~/.nixis/`. Run without `-y` to confirm each step interactively.
+
 ## Try It
 
 After setup, the daemon is running. Test policies instantly:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Nixis intercepts every tool call your AI assistant makes — file writes, shell commands, network access — and evaluates it against security policies in under 200ms. If the action violates policy, Nixis blocks it before execution. No prompt engineering. No trust assumptions. External enforcement.
 
-> `install → nixis setup → your agent is guardrailed.` Three commands, two minutes, 44 policies active.
+> `curl install.sh | sh` → `source ~/.zshrc && nixis setup` — two commands, two minutes, 44 policies active.
 
 ## The Problem
 
@@ -31,12 +31,17 @@ The only guardrail today is hoping the model says no. Nixis enforces externally 
 # One-liner (recommended)
 curl -sSfL https://raw.githubusercontent.com/mayankjain0141/nixis/main/install.sh | sh
 
+# Then reload your shell and run setup (the installer will print the exact command):
+source ~/.zshrc && nixis setup
+
 # Via Go (CLI only — use curl installer for full daemon + hook)
 go install github.com/mayankjain0141/nixis/cmd/nixis@latest
 
 # From source
 git clone https://github.com/mayankjain0141/nixis.git && cd nixis && make install
 ```
+
+> The installer adds `~/.nixis` to your PATH via your shell config (`.zshrc`, `.bashrc`, etc.) and prints the exact `source` command to run. You don't need to edit anything manually.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 Nixis intercepts every tool call your AI assistant makes — file writes, shell commands, network access — and evaluates it against security policies in under 200ms. If the action violates policy, Nixis blocks it before execution. No prompt engineering. No trust assumptions. External enforcement.
 
-> `curl install.sh | sh` → `source ~/.zshrc && nixis setup` — two commands, two minutes, 44 policies active.
-
 ## The Problem
 
 AI coding agents (Claude Code, Cursor, Copilot) have unrestricted tool access. They can:
@@ -27,45 +25,47 @@ The only guardrail today is hoping the model says no. Nixis enforces externally 
 
 ## Install
 
+### End Users
+
+One command. The installer downloads binaries, adds `~/.nixis` to PATH, and fully configures the daemon, policies, and IDE hook automatically.
+
 ```bash
-# One-liner (recommended)
 curl -sSfL https://raw.githubusercontent.com/mayankjain0141/nixis/main/install.sh | sh
+```
 
-# Then reload your shell and run setup (the installer will print the exact command):
-source ~/.zshrc && nixis setup
+After it completes, reload your shell with the printed `source` command and you're done. No manual `nixis setup` step required.
 
-# Via Go (CLI only — use curl installer for full daemon + hook)
+### From Source
+
+```bash
+# First-time setup (generates test keys, installs Node deps, builds, deploys):
+git clone https://github.com/mayankjain0141/nixis.git && cd nixis
+make dev-install
+
+# Subsequent rebuilds — idempotent, stops old daemon and restarts with new binary:
+make install
+```
+
+### CLI Only (no daemon)
+
+```bash
 go install github.com/mayankjain0141/nixis/cmd/nixis@latest
-
-# From source
-git clone https://github.com/mayankjain0141/nixis.git && cd nixis && make install
+nixis setup   # configure daemon + hook after installing
 ```
 
-> The installer adds `~/.nixis` to your PATH via your shell config (`.zshrc`, `.bashrc`, etc.) and prints the exact `source` command to run. You don't need to edit anything manually.
+Useful for CI pipelines and environments where you want just the CLI tools.
 
-## Setup
+### Requirements
 
-One command configures everything — daemon, policies, IDE hook:
+| Requirement | Version | When needed |
+|-------------|---------|-------------|
+| macOS or Linux | amd64 / arm64 | Always |
+| Go | 1.25+ | Source builds only |
+| Node.js | 26+ | Dashboard dev (`make dev`, `make dev-install`) |
 
-```
-$ nixis setup
+## Quickstart
 
-Nixis Setup
-===========
-[1/8] Detecting binaries...
-[2/8] Deploying to ~/.nixis/
-[3/8] Creating policy directories...
-[4/8] Installing 750+ builtin policies...
-[5/8] Installing daemon service (launchd/systemd, auto-start)...
-[6/8] Patching ~/.claude/settings.json (PreToolUse hook)...
-[7/8] Smoke test... ✓
-[8/8] Cleaning up...
-
-✓ Nixis setup complete!
-  Run 'nixis doctor' to verify installation health.
-```
-
-Verify everything works:
+After installation, verify everything works:
 
 ```
 $ nixis doctor
@@ -73,31 +73,17 @@ $ nixis doctor
 Nixis Health Check
 ==================
   Daemon:      ✓ running (PID 48291, uptime 12s)
-  Socket:      ✓ /tmp/nixis.sock (mode 0700)
+  Socket:      ✓ /tmp/nixis.sock (mode 0600)
   Hook:        ✓ ~/.nixis/nixis-hook (executable)
-  Settings:    ✓ PreToolUse hook configured
-  Policies:    ✓ engine ok, 763 policies loaded
+  Settings:    ✓ PreToolUse hook configured with literal path
+  Policies:    ✓ engine ok, 44 evaluations served
   Fail-open:   ✓ 0 events in last 24h
   Heartbeat:   ✓ daemon responsive
 
-Overall: HEALTHY
+Overall: HEALTHY (0 warnings)
 ```
 
-That's it. Every tool call your agent makes is now evaluated against 44 security policies.
-
-**Currently supported:** Claude Code (via PreToolUse hook). Cursor and other MCP-based agents work via the gRPC ext_authz or HTTP API integration.
-
-## Uninstall
-
-```bash
-nixis setup --uninstall -y
-```
-
-This stops the daemon service, removes the PreToolUse hook from `~/.claude/settings.json`, and deletes `~/.nixis/`. Run without `-y` to confirm each step interactively.
-
-## Try It
-
-After setup, the daemon is running. Test policies instantly:
+Test policies instantly:
 
 ```bash
 # Reverse shell — blocked
@@ -120,12 +106,14 @@ action=deny policy=nixis/no-secret-transmission layer=secret latency=3200ns
 reason=Secret detected in outbound request
 ```
 
-## CLI
+## CLI Reference
 
 | Command | What it does |
 |---------|-------------|
-| `nixis setup` | One-command install wizard — daemon, policies, IDE hook |
-| `nixis doctor` | Health check with pass/warn/fail verdicts |
+| `nixis setup` | Wizard: installs policies, starts daemon service, registers IDE hook |
+| `nixis uninstall` | Completely remove Nixis — daemon, service, hook, PATH entry, all files. `--force` bypasses launchctl/systemctl for recovery when stuck. |
+| `nixis reload` | Hot-reload policies from disk without restarting the daemon |
+| `nixis doctor` | Health check — daemon, socket, hook, policies, port conflicts |
 | `nixis simulate <tool>` | Test a tool call against live policies |
 | `nixis scan <mcp-server>` | Discover and classify MCP tools by risk level |
 | `nixis daemon status` | Show daemon health, uptime, evaluation count |
@@ -187,6 +175,37 @@ flowchart LR
 - **Policy Import** — Auto-convert from Kyverno, Sigma, Falco, OPA Gatekeeper, AgentWall, Checkov, and more. LLM-assisted CEL translation for complex rules.
 - **gRPC ext_authz** — Drop-in Envoy/Istio integration for service mesh deployments.
 
+## Managing Policies
+
+**Hot-reload after editing a policy (from source):**
+
+```bash
+make update-policies   # rsync ./policies/ → ~/.nixis/policies/ then hot-reloads the daemon
+```
+
+**Reload from the installed directory (no source needed):**
+
+```bash
+nixis reload
+```
+
+**Rebuild binaries and policies together after code changes:**
+
+```bash
+make install   # build → stop daemon → deploy binaries → restart daemon
+```
+
+**Policy directory layout in `~/.nixis/policies/`:**
+
+```
+policies/
+  builtin/     # 44 policies enabled by default — updated by make install
+  imported/    # 700+ converted from Kyverno/Sigma/Falco/OPA — opt-in
+  custom/      # your own policies — never overwritten by make install
+```
+
+Add your own policies to `custom/` and run `nixis reload`. They take effect immediately.
+
 ## Policy Example
 
 ```yaml
@@ -215,7 +234,7 @@ spec:
   defaultAction: ALLOW
 ```
 
-**44 built-in policies** ship enabled by default, covering credential exfiltration, destructive commands, reverse shells, privilege escalation, supply chain attacks, and more. An additional **700+ community policies** (converted from Kyverno, Sigma, OPA Gatekeeper, AgentWall) are available in `policies/imported/` for opt-in use.
+**44 builtin policies** ship enabled by default, covering credential exfiltration, destructive commands, reverse shells, privilege escalation, and supply chain attacks. An additional **700+ community policies** (converted from Kyverno, Sigma, OPA Gatekeeper, AgentWall) are available in `policies/imported/` for opt-in use.
 
 ## Why Not...
 
@@ -246,9 +265,81 @@ Nixis ships with a 784-case adversarial benchmark (`eval/`) covering 7 attack ca
 
 **Overall precision: 92%.** Train/test gap is small (F1: 84% vs 80%) — no overfitting. See [eval/adversarial/EVAL_BENCH.md](eval/adversarial/EVAL_BENCH.md) for methodology and per-case results.
 
+## Troubleshooting
+
+**Daemon won't start — port already in use**
+
+```bash
+lsof -i :9090                                  # find what's using the port
+NIXIS_DASHBOARD_ADDR=127.0.0.1:9092 nixis setup  # use a different port
+```
+
+**`nixis doctor` or `nixis uninstall` hangs indefinitely**
+
+This happens when macOS launchd or Linux systemd has the service in a corrupt state. Try `--force` first:
+
+```bash
+nixis uninstall --force --yes
+```
+
+If even that hangs (you'll see the process in uninterruptible sleep), nuclear option in a new terminal:
+
+```bash
+pgrep -f nixis | xargs kill -9 2>/dev/null
+
+# macOS:
+rm -f ~/Library/LaunchAgents/com.nixis.daemon.plist
+
+# Linux:
+rm -f ~/.config/systemd/user/nixis-daemon.service
+systemctl --user daemon-reload
+
+rm -rf ~/.nixis && rm -f /tmp/nixis.sock
+# Remove the '# Nixis' block from your shell rc file manually, then:
+curl -sSfL https://raw.githubusercontent.com/mayankjain0141/nixis/main/install.sh | sh
+```
+
+**"text file busy" on upgrade (pre-v0.x installs only)**
+
+Fixed in the current release — the installer uses atomic rename. If you're on an older binary, uninstall first:
+
+```bash
+nixis uninstall --force --yes
+curl -sSfL https://raw.githubusercontent.com/mayankjain0141/nixis/main/install.sh | sh
+```
+
+**`make dev-install` fails on first clone**
+
+Check toolchain versions and run the one-time setup:
+
+```bash
+go version      # need 1.25+
+node --version  # need v26+ (only required for make dev-install / make dev)
+make test-keys  # generates Ed25519 test key pair (run once after clone)
+```
+
 ## Contributing
 
-See [CONTRIBUTING.md](.github/CONTRIBUTING.md). Prerequisites: Go 1.25+, Node 20+.
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+
+**Prerequisites:** Go 1.25+, Node 26+
+
+```bash
+git clone https://github.com/mayankjain0141/nixis.git && cd nixis
+
+# One-time setup: generate test keys + install pre-push CI hook
+make test-keys
+make install-hooks   # runs 'make ci' before every git push
+
+# Development workflow
+make dev-install     # first-time full setup (build + daemon + dashboard)
+make install         # rebuild + redeploy after code changes
+make ci              # run the same checks as GitHub CI (build + test + lint)
+make test            # Go tests only (faster iteration)
+make lint            # golangci-lint only
+make dev             # start daemon + dashboard dev server with hot-reload
+make update-policies # sync policy changes to installed dir + hot-reload
+```
 
 ## Attributions
 

--- a/cmd/nixis-daemon/main.go
+++ b/cmd/nixis-daemon/main.go
@@ -16,11 +16,14 @@ package main
 import (
 	"context"
 	"crypto/ed25519"
+	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/mayankjain0141/nixis/internal/audit"
@@ -159,11 +162,12 @@ func main() {
 	}
 
 	// Start reload watcher after initial policy load (spec: started AFTER initial compile).
-	reloadWatcher, rwErr := reload.NewReloadWatcher(cfg.PolicyDir, &policyReloader{
+	pr := &policyReloader{
 		policyDir: cfg.PolicyDir,
 		engine:    engine,
 		ctx:       ctx,
-	})
+	}
+	reloadWatcher, rwErr := reload.NewReloadWatcher(cfg.PolicyDir, pr)
 	if rwErr != nil {
 		fmt.Fprintf(os.Stderr, "nixis-daemon: failed to create reload watcher: %v\n", rwErr)
 	} else {
@@ -190,7 +194,12 @@ func main() {
 			addr = "127.0.0.1:9090"
 		}
 		if err := streamSrv.Start(streamCtx, addr); err != nil && streamCtx.Err() == nil {
-			fmt.Fprintf(os.Stderr, "nixis-daemon: stream server error: %v\n", err)
+			if isAddrInUse(err) {
+				_, port, _ := net.SplitHostPort(addr)
+				fmt.Fprintf(os.Stderr, "FATAL: Cannot bind %s — port already in use.\n  Check: lsof -i :%s\n  Fix: set NIXIS_DASHBOARD_ADDR=127.0.0.1:<other-port>\n", addr, port)
+			} else {
+				fmt.Fprintf(os.Stderr, "nixis-daemon: stream server error: %v\n", err)
+			}
 		}
 	}()
 	// Wire audit checkpoint → stream event so the dashboard Forensic Review shows live data.
@@ -250,6 +259,7 @@ func main() {
 
 	d := daemon.New(cfg, engine, auditWriter, streamSrv, sessions)
 	d.SetDelegationEngine(delegEngine)
+	d.SetReloader(pr)
 	d.SetAuditContext(cancel, auditDone)
 
 	if err := d.Run(ctx); err != nil {
@@ -289,4 +299,16 @@ func expandHome(path string) string {
 		return path
 	}
 	return home + path[1:]
+}
+
+// isAddrInUse reports whether the error is caused by EADDRINUSE.
+func isAddrInUse(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		var sysErr *os.SyscallError
+		if errors.As(opErr.Err, &sysErr) {
+			return errors.Is(sysErr.Err, syscall.EADDRINUSE)
+		}
+	}
+	return false
 }

--- a/cmd/nixis/doctor.go
+++ b/cmd/nixis/doctor.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -65,14 +66,16 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	// Check 8: Heartbeat
 	checks = append(checks, checkHeartbeat())
 
+	// Check 9: Port conflicts
+	checks = append(checks, checkPortConflicts())
+
 	for _, c := range checks {
 		mark := "✓"
-		if c.warning {
-			mark = "⚠"
-			warnings++
-		}
 		if c.status == "FAIL" {
 			mark = "✗"
+			warnings++
+		} else if c.warning {
+			mark = "⚠"
 			warnings++
 		}
 		fmt.Fprintf(w, "  %-14s %s %s\n", c.name+":", mark, c.detail)
@@ -88,7 +91,7 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 }
 
 func checkDaemon() doctorCheck {
-	running, pid, err := daemonServiceStatus()
+	running, pid, err := daemonServiceStatusWithTimeout(3 * time.Second)
 	if err != nil {
 		return doctorCheck{name: "Daemon", status: "FAIL", detail: fmt.Sprintf("error checking status: %v", err), warning: true}
 	}
@@ -283,4 +286,48 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dm%ds", minutes, int(d.Seconds())%60)
 	}
 	return fmt.Sprintf("%ds", int(d.Seconds()))
+}
+
+func checkPortConflicts() doctorCheck {
+	// Port 9091 is the healthz/API port — verify ownership via /healthz.
+	// Port 9090 is the WebSocket/dashboard stream port — has no /healthz, so
+	// verify ownership by confirming 9091 is up (same process owns both).
+	var conflicts []string
+
+	// Check 9091 first: if it responds with 200, nixis owns both ports.
+	nixisOwns9091 := false
+	client := &http.Client{Timeout: 2 * time.Second}
+	if resp, err := client.Get("http://127.0.0.1:9091/healthz"); err == nil {
+		_ = resp.Body.Close()
+		nixisOwns9091 = resp.StatusCode == http.StatusOK
+	}
+
+	// Check 9090: if it's bound but nixis doesn't own 9091, it's a conflict.
+	conn90, err := net.DialTimeout("tcp", "127.0.0.1:9090", 1*time.Second)
+	if err == nil {
+		_ = conn90.Close()
+		if !nixisOwns9091 {
+			conflicts = append(conflicts, "9090")
+		}
+	}
+
+	// Check 9091: if it's bound but didn't respond to /healthz, it's a conflict.
+	conn91, err := net.DialTimeout("tcp", "127.0.0.1:9091", 1*time.Second)
+	if err == nil {
+		_ = conn91.Close()
+		if !nixisOwns9091 {
+			conflicts = append(conflicts, "9091")
+		}
+	}
+
+	if len(conflicts) > 0 {
+		return doctorCheck{
+			name:   "Ports",
+			status: "FAIL",
+			detail: fmt.Sprintf("port(s) %s occupied by non-Nixis process (check: lsof -i :%s)",
+				strings.Join(conflicts, ", "), conflicts[0]),
+			warning: false,
+		}
+	}
+	return doctorCheck{name: "Ports", status: "OK", detail: "9090/9091 owned by Nixis"}
 }

--- a/cmd/nixis/main.go
+++ b/cmd/nixis/main.go
@@ -27,6 +27,8 @@ func init() {
 	rootCmd.AddCommand(setupCmd)
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(daemonCmd)
+	rootCmd.AddCommand(reloadCmd)
+	rootCmd.AddCommand(uninstallCmd)
 }
 
 func main() {

--- a/cmd/nixis/reload.go
+++ b/cmd/nixis/reload.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var reloadCmd = &cobra.Command{
+	Use:   "reload",
+	Short: "Signal the daemon to reload policies from disk",
+	Long:  `Triggers an immediate policy reload on the running daemon via its HTTP API.`,
+	RunE:  runReload,
+}
+
+func runReload(cmd *cobra.Command, _ []string) error {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Post("http://127.0.0.1:9091/reload", "", nil)
+	if err != nil {
+		return fmt.Errorf("daemon unreachable (is it running?): %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("reload failed: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Policies reloaded.")
+	return nil
+}

--- a/cmd/nixis/setup.go
+++ b/cmd/nixis/setup.go
@@ -206,9 +206,23 @@ func runInstall(cmd *cobra.Command, homeDir, nixisDir string) error {
 		}
 	}
 
+	// Step 9: Patch shell PATH (always — mirrors what Homebrew does)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "[9/9] Patching shell PATH...")
+	shellConfig, patched, err := patchShellPATH(w, nixisDir)
+	if err != nil {
+		fmt.Fprintf(w, "  Warning: could not patch PATH: %v\n", err)
+		fmt.Fprintf(w, "  Add this manually: export PATH=\"%s:$PATH\"\n", nixisDir)
+	}
+
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "✓ Nixis setup complete!")
-	fmt.Fprintf(w, "  Run 'nixis doctor' to verify installation health.\n")
+	if patched && shellConfig != "" {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "  Run this to use nixis in your current shell:")
+		fmt.Fprintf(w, "\n    source %s\n\n", shellConfig)
+	}
+	fmt.Fprintf(w, "  Then verify: nixis doctor\n")
 	return nil
 }
 
@@ -534,4 +548,96 @@ func confirm(prompt string) bool {
 	line, _ := reader.ReadString('\n')
 	line = strings.TrimSpace(strings.ToLower(line))
 	return line == "" || line == "y" || line == "yes"
+}
+
+// patchShellPATH adds nixisDir to PATH in the user's shell config if not already present.
+// Returns (configFile, didPatch, error). Mirrors what install.sh's add_to_path does
+// so that `nixis setup` and `make dev-install` behave identically to the curl installer.
+func patchShellPATH(w io.Writer, nixisDir string) (string, bool, error) {
+	// Already in the current process's PATH — nothing to write, but tell the user.
+	inPath := false
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == nixisDir {
+			inPath = true
+			break
+		}
+	}
+
+	cfg := detectShellConfig()
+	if cfg == "" {
+		if inPath {
+			fmt.Fprintln(w, "  Already in PATH")
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("could not detect shell config file")
+	}
+
+	// Already written to this config — skip silently.
+	if data, err := os.ReadFile(cfg); err == nil {
+		if strings.Contains(string(data), nixisDir) {
+			if inPath {
+				fmt.Fprintf(w, "  PATH already configured in %s\n", cfg)
+			} else {
+				// Written but not sourced yet — still print the source hint.
+				fmt.Fprintf(w, "  PATH already configured in %s (not yet sourced)\n", cfg)
+			}
+			return cfg, false, nil
+		}
+	}
+
+	if setupDryRun {
+		fmt.Fprintf(w, "  (dry-run) Would add %s to PATH in %s\n", nixisDir, cfg)
+		return cfg, false, nil
+	}
+
+	shell := filepath.Base(os.Getenv("SHELL"))
+	var line string
+	if shell == "fish" {
+		line = fmt.Sprintf("\n# Nixis\nfish_add_path %s\n", nixisDir)
+	} else {
+		line = fmt.Sprintf("\n# Nixis\nexport PATH=\"%s:$PATH\"\n", nixisDir)
+	}
+
+	f, err := os.OpenFile(cfg, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return cfg, false, fmt.Errorf("open %s: %w", cfg, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(line); err != nil {
+		return cfg, false, fmt.Errorf("write %s: %w", cfg, err)
+	}
+
+	fmt.Fprintf(w, "  Added %s to PATH in %s\n", nixisDir, cfg)
+	return cfg, true, nil
+}
+
+// detectShellConfig returns the most appropriate shell rc file to write PATH into.
+func detectShellConfig() string {
+	homeDir, _ := os.UserHomeDir()
+	shell := filepath.Base(os.Getenv("SHELL"))
+
+	candidates := map[string]string{
+		"zsh":  filepath.Join(homeDir, ".zshrc"),
+		"bash": filepath.Join(homeDir, ".bashrc"),
+		"fish": filepath.Join(homeDir, ".config", "fish", "config.fish"),
+	}
+
+	if cfg, ok := candidates[shell]; ok {
+		if _, err := os.Stat(cfg); err == nil {
+			return cfg
+		}
+	}
+
+	// Fall back to first existing file.
+	for _, f := range []string{
+		filepath.Join(homeDir, ".zshrc"),
+		filepath.Join(homeDir, ".bashrc"),
+		filepath.Join(homeDir, ".bash_profile"),
+		filepath.Join(homeDir, ".profile"),
+	} {
+		if _, err := os.Stat(f); err == nil {
+			return f
+		}
+	}
+	return ""
 }

--- a/cmd/nixis/setup.go
+++ b/cmd/nixis/setup.go
@@ -7,19 +7,23 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	setupYes       bool
-	setupUninstall bool
-	setupDryRun    bool
-	setupPolicyDir string
+	setupYes          bool
+	setupUninstall    bool
+	setupDryRun       bool
+	setupPolicyDir    string
+	setupSkipBinaries bool
 )
 
 var setupCmd = &cobra.Command{
@@ -35,6 +39,7 @@ func init() {
 	setupCmd.Flags().BoolVar(&setupUninstall, "uninstall", false, "Remove Nixis installation")
 	setupCmd.Flags().BoolVar(&setupDryRun, "dry-run", false, "Show what would be done without making changes")
 	setupCmd.Flags().StringVar(&setupPolicyDir, "policy-dir", "", "Source policy directory (default: ./policies)")
+	setupCmd.Flags().BoolVar(&setupSkipBinaries, "skip-binaries", false, "Skip binary deployment (use when binaries are already in place)")
 }
 
 func runSetup(cmd *cobra.Command, _ []string) error {
@@ -61,37 +66,45 @@ func runInstall(cmd *cobra.Command, homeDir, nixisDir string) error {
 	fmt.Fprintln(w, "[1/8] Detecting binaries...")
 	binaries := []string{"nixis", "nixis-hook", "nixis-daemon"}
 	binSources := make(map[string]string, len(binaries))
-	for _, name := range binaries {
-		path := findBinary(name)
-		if path == "" {
-			return fmt.Errorf("binary %q not found in PATH or current directory; run 'go build ./cmd/%s/' first", name, name)
+	if !setupSkipBinaries {
+		for _, name := range binaries {
+			path := findBinary(name)
+			if path == "" {
+				return fmt.Errorf("binary %q not found in PATH or current directory; run 'go build ./cmd/%s/' first", name, name)
+			}
+			binSources[name] = path
+			fmt.Fprintf(w, "  Found: %s → %s\n", name, path)
 		}
-		binSources[name] = path
-		fmt.Fprintf(w, "  Found: %s → %s\n", name, path)
+	} else {
+		fmt.Fprintln(w, "  Skipped (--skip-binaries)")
 	}
 
 	// Step 2: Deploy binaries to ~/.nixis/
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "[2/8] Deploying binaries to", nixisDir)
-	if err := os.MkdirAll(nixisDir, 0o755); err != nil && !setupDryRun {
-		return fmt.Errorf("create %s: %w", nixisDir, err)
-	}
-	for _, name := range binaries {
-		dest := filepath.Join(nixisDir, name)
-		fmt.Fprintf(w, "  %s → %s\n", binSources[name], dest)
-		if !setupDryRun {
-			if err := copyFile(binSources[name], dest, 0o755); err != nil {
-				return fmt.Errorf("deploy %s: %w", name, err)
+	if !setupSkipBinaries {
+		if err := os.MkdirAll(nixisDir, 0o755); err != nil && !setupDryRun {
+			return fmt.Errorf("create %s: %w", nixisDir, err)
+		}
+		for _, name := range binaries {
+			dest := filepath.Join(nixisDir, name)
+			fmt.Fprintf(w, "  %s → %s\n", binSources[name], dest)
+			if !setupDryRun {
+				if err := copyFile(binSources[name], dest, 0o755); err != nil {
+					return fmt.Errorf("deploy %s: %w", name, err)
+				}
 			}
 		}
+	} else {
+		fmt.Fprintln(w, "  Skipped (--skip-binaries)")
 	}
 
 	// Step 3: Create policy directories
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "[3/8] Creating policy directories...")
-	builtinDir := filepath.Join(nixisDir, "policies", "builtin")
-	customDir := filepath.Join(nixisDir, "policies", "custom")
-	for _, dir := range []string{builtinDir, customDir} {
+	policyDestDir := filepath.Join(nixisDir, "policies")
+	customDir := filepath.Join(policyDestDir, "custom")
+	for _, dir := range []string{policyDestDir, customDir} {
 		fmt.Fprintf(w, "  mkdir -p %s\n", dir)
 		if !setupDryRun {
 			if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -107,7 +120,7 @@ func runInstall(cmd *cobra.Command, homeDir, nixisDir string) error {
 	if policySource == "" {
 		policySource = "./policies"
 	}
-	if err := copyPolicies(w, policySource, builtinDir); err != nil {
+	if err := copyPolicies(w, policySource, policyDestDir); err != nil {
 		return fmt.Errorf("install policies: %w", err)
 	}
 
@@ -122,6 +135,38 @@ func runInstall(cmd *cobra.Command, homeDir, nixisDir string) error {
 		fmt.Fprintln(w, "  Daemon service installed")
 	} else {
 		fmt.Fprintln(w, "  (dry-run) Would install daemon service")
+	}
+
+	// Step 5b: Restart daemon
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "[5b/8] Managing daemon lifecycle...")
+	if !setupDryRun {
+		running, pid, _ := daemonServiceStatusWithTimeout(3 * time.Second)
+		if running {
+			fmt.Fprintf(w, "  Restarting daemon (PID %d)...\n", pid)
+			if err := stopDaemonWithTimeout(5 * time.Second); err != nil {
+				fmt.Fprintf(w, "  Warning: graceful stop failed (%v), force-killing...\n", err)
+				if p := findDaemonPID(); p > 0 {
+					_ = syscall.Kill(p, syscall.SIGKILL)
+					time.Sleep(500 * time.Millisecond)
+				}
+			}
+			if err := startDaemon(); err != nil {
+				fmt.Fprintf(w, "  Warning: restart failed: %v\n", err)
+			} else {
+				fmt.Fprintln(w, "  Daemon restarted")
+				waitForDaemon(w)
+			}
+		} else {
+			if err := startDaemon(); err != nil {
+				fmt.Fprintf(w, "  Warning: could not start daemon: %v\n", err)
+			} else {
+				fmt.Fprintln(w, "  Daemon started")
+				waitForDaemon(w)
+			}
+		}
+	} else {
+		fmt.Fprintln(w, "  (dry-run) Would restart daemon")
 	}
 
 	// Step 6: Patch settings.json
@@ -214,10 +259,10 @@ func runUninstall(cmd *cobra.Command, homeDir, nixisDir string) error {
 }
 
 func findBinary(name string) string {
-	// Check current directory build output first
 	candidates := []string{
+		filepath.Join("bin", name),
 		"./" + name,
-		"./cmd/" + name + "/" + name,
+		filepath.Join("cmd", name, name),
 	}
 	for _, c := range candidates {
 		if info, err := os.Stat(c); err == nil && !info.IsDir() {
@@ -225,7 +270,15 @@ func findBinary(name string) string {
 			return abs
 		}
 	}
-	// Check PATH
+	// Fallback: already-installed copy
+	homeDir, _ := os.UserHomeDir()
+	installed := filepath.Join(homeDir, ".nixis", name)
+	if info, err := os.Stat(installed); err == nil && !info.IsDir() {
+		fmt.Fprintf(os.Stderr, "  WARNING: No fresh build found for %s, using installed copy at %s\n", name, installed)
+		fmt.Fprintf(os.Stderr, "           Did you forget 'make build'?\n")
+		return installed
+	}
+	// Check PATH last
 	if p, err := exec.LookPath(name); err == nil {
 		return p
 	}
@@ -233,38 +286,53 @@ func findBinary(name string) string {
 }
 
 func copyFile(src, dst string, mode fs.FileMode) error {
+	absSrc, err := filepath.Abs(src)
+	if err != nil {
+		return err
+	}
+	absDst, err := filepath.Abs(dst)
+	if err != nil {
+		return err
+	}
+	if absSrc == absDst {
+		return nil
+	}
+
 	srcInfo, err := os.Stat(src)
 	if err != nil {
 		return err
 	}
-	// If dst exists: skip when it's the same inode (binary copying onto itself),
-	// otherwise unlink before writing to avoid ETXTBSY on Linux when overwriting
-	// a running executable.
 	if dstInfo, err := os.Stat(dst); err == nil {
 		if os.SameFile(srcInfo, dstInfo) {
 			return nil
 		}
-		if err := os.Remove(dst); err != nil {
-			return fmt.Errorf("remove existing %s: %w", dst, err)
-		}
 	}
 
+	tmpDst := dst + ".tmp"
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = in.Close() }()
 
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	out, err := os.OpenFile(tmpDst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = out.Close() }()
-
 	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmpDst)
 		return err
 	}
-	return out.Chmod(mode)
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmpDst)
+		return err
+	}
+	if err := os.Rename(tmpDst, dst); err != nil {
+		_ = os.Remove(tmpDst)
+		return err
+	}
+	return os.Chmod(dst, mode)
 }
 
 func copyPolicies(w io.Writer, srcDir, destDir string) error {
@@ -316,6 +384,32 @@ func copyPolicies(w io.Writer, srcDir, destDir string) error {
 	}
 	fmt.Fprintf(w, "  Installed %d policy files\n", count)
 	return nil
+}
+
+// waitForDaemon polls until the daemon healthz endpoint responds or 10s elapses.
+// Called immediately after startDaemon() because launchctl/systemctl returns
+// before the process has bound its socket and HTTP server.
+func waitForDaemon(w io.Writer) {
+	fmt.Fprintf(w, "  Waiting for daemon to be ready")
+	client := &http.Client{Timeout: 1 * time.Second}
+	socketPath := daemonSocketPath()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		// Check healthz HTTP endpoint
+		if resp, err := client.Get("http://127.0.0.1:9091/healthz"); err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				// Also wait for socket
+				if _, serr := os.Stat(socketPath); serr == nil {
+					fmt.Fprintln(w, " ready.")
+					return
+				}
+			}
+		}
+		fmt.Fprintf(w, ".")
+		time.Sleep(500 * time.Millisecond)
+	}
+	fmt.Fprintln(w, " timed out (run 'nixis doctor' to check status).")
 }
 
 func isYAML(name string) bool {

--- a/cmd/nixis/setup.go
+++ b/cmd/nixis/setup.go
@@ -336,51 +336,41 @@ func copyFile(src, dst string, mode fs.FileMode) error {
 }
 
 func copyPolicies(w io.Writer, srcDir, destDir string) error {
-	entries, err := os.ReadDir(srcDir)
-	if err != nil {
+	// Confirm srcDir exists before walking.
+	if _, err := os.Stat(srcDir); err != nil {
 		return fmt.Errorf("read %s: %w", srcDir, err)
 	}
 
 	count := 0
-	for _, entry := range entries {
-		if entry.IsDir() {
-			subSrc := filepath.Join(srcDir, entry.Name())
-			subDest := filepath.Join(destDir, entry.Name())
-			if !setupDryRun {
-				if err := os.MkdirAll(subDest, 0o755); err != nil {
-					return err
-				}
-			}
-			subEntries, err := os.ReadDir(subSrc)
-			if err != nil {
-				return err
-			}
-			for _, se := range subEntries {
-				if se.IsDir() || !isYAML(se.Name()) {
-					continue
-				}
-				src := filepath.Join(subSrc, se.Name())
-				dst := filepath.Join(subDest, se.Name())
-				if !setupDryRun {
-					if err := copyFile(src, dst, 0o644); err != nil {
-						return err
-					}
-				}
-				count++
-			}
-			continue
+	err := filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		if !isYAML(entry.Name()) {
-			continue
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
 		}
-		src := filepath.Join(srcDir, entry.Name())
-		dst := filepath.Join(destDir, entry.Name())
+		dst := filepath.Join(destDir, rel)
+
+		if d.IsDir() {
+			if setupDryRun {
+				return nil
+			}
+			return os.MkdirAll(dst, 0o755)
+		}
+		if !isYAML(d.Name()) {
+			return nil
+		}
 		if !setupDryRun {
-			if err := copyFile(src, dst, 0o644); err != nil {
+			if err := copyFile(path, dst, 0o644); err != nil {
 				return err
 			}
 		}
 		count++
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	fmt.Fprintf(w, "  Installed %d policy files\n", count)
 	return nil

--- a/cmd/nixis/setup.go
+++ b/cmd/nixis/setup.go
@@ -233,6 +233,22 @@ func findBinary(name string) string {
 }
 
 func copyFile(src, dst string, mode fs.FileMode) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	// If dst exists: skip when it's the same inode (binary copying onto itself),
+	// otherwise unlink before writing to avoid ETXTBSY on Linux when overwriting
+	// a running executable.
+	if dstInfo, err := os.Stat(dst); err == nil {
+		if os.SameFile(srcInfo, dstInfo) {
+			return nil
+		}
+		if err := os.Remove(dst); err != nil {
+			return fmt.Errorf("remove existing %s: %w", dst, err)
+		}
+	}
+
 	in, err := os.Open(src)
 	if err != nil {
 		return err

--- a/cmd/nixis/setup_darwin.go
+++ b/cmd/nixis/setup_darwin.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -85,10 +86,14 @@ func installDaemonService(homeDir, policyDir string, yes bool) error {
 		return fmt.Errorf("write plist: %w", err)
 	}
 
+	// Purge any prior registration before bootstrapping so we never hit
+	// "Bad request" from a stale entry left by a previous install.
+	purgeServiceFromLaunchd()
+
 	// Load the service
 	cmd := exec.Command("launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), dest)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		// Fallback to legacy load if bootstrap not available
+		// Fallback to legacy load if bootstrap not available (macOS < Ventura).
 		cmd2 := exec.Command("launchctl", "load", dest)
 		if output2, err2 := cmd2.CombinedOutput(); err2 != nil {
 			return fmt.Errorf("launchctl load failed: %w (%s; bootstrap: %s)", err2,
@@ -161,11 +166,20 @@ func startDaemon() error {
 	if _, err := os.Stat(dest); os.IsNotExist(err) {
 		return fmt.Errorf("plist not found at %s; run 'nixis setup' first", dest)
 	}
+
+	// Purge any ghost registration before bootstrapping. Without this, a
+	// prior `launchctl load` (legacy path) or a crashed daemon can leave the
+	// label partially registered, causing bootstrap to return "Bad request".
+	purgeServiceFromLaunchd()
+
 	cmd := exec.Command("launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), dest)
 	if output, err := cmd.CombinedOutput(); err != nil {
+		// Last-resort fallback for macOS < Ventura where bootstrap is unavailable.
+		// purgeServiceFromLaunchd() already cleared legacy registrations above, so
+		// load won't accumulate a ghost on top of an existing entry.
 		cmd2 := exec.Command("launchctl", "load", dest)
 		if output2, err2 := cmd2.CombinedOutput(); err2 != nil {
-			return fmt.Errorf("start daemon: %w (%s; %s)", err2,
+			return fmt.Errorf("start daemon: %w (%s; bootstrap: %s)", err2,
 				strings.TrimSpace(string(output2)), strings.TrimSpace(string(output)))
 		}
 	}
@@ -177,10 +191,14 @@ func stopDaemon() error {
 	if output, err := cmd.CombinedOutput(); err != nil {
 		cmd2 := exec.Command("launchctl", "unload", plistPath())
 		if output2, err2 := cmd2.CombinedOutput(); err2 != nil {
+			// Both launchctl calls failed; still attempt to kill the process
+			// so the caller doesn't inherit an orphan.
+			killDaemonProcess()
 			return fmt.Errorf("stop daemon: %w (%s; %s)", err2,
 				strings.TrimSpace(string(output2)), strings.TrimSpace(string(output)))
 		}
 	}
+	killDaemonProcess()
 	return nil
 }
 
@@ -190,16 +208,49 @@ func stopDaemonWithTimeout(timeout time.Duration) error {
 	cmd := exec.CommandContext(ctx, "launchctl", "bootout", fmt.Sprintf("gui/%d/%s", os.Getuid(), plistLabel))
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
+		killDaemonProcess()
 		return fmt.Errorf("launchctl timed out after %v (service may be stuck)", timeout)
 	}
 	if err != nil {
 		cmd2 := exec.CommandContext(ctx, "launchctl", "unload", plistPath())
 		if output2, err2 := cmd2.CombinedOutput(); err2 != nil {
+			killDaemonProcess()
 			return fmt.Errorf("stop daemon: %w (%s; %s)", err2,
 				strings.TrimSpace(string(output2)), strings.TrimSpace(string(output)))
 		}
 	}
+	killDaemonProcess()
 	return nil
+}
+
+// killDaemonProcess sends SIGTERM to the daemon process and waits up to 1s
+// for it to exit, then sends SIGKILL. The PID is re-fetched before SIGKILL to
+// avoid sending the signal to a different process that may have been assigned
+// the same PID after the original daemon exited.
+func killDaemonProcess() {
+	pid := findDaemonPID()
+	if pid <= 0 {
+		return
+	}
+	_ = syscall.Kill(pid, syscall.SIGTERM)
+	for i := 0; i < 10; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if findDaemonPID() == 0 {
+			return
+		}
+	}
+	// Re-fetch PID: the original process may have died and launchd (if not yet
+	// booted out) could have restarted a new instance with a different PID.
+	if fresh := findDaemonPID(); fresh > 0 {
+		_ = syscall.Kill(fresh, syscall.SIGKILL)
+		// Wait until the kernel reaps the process before returning.
+		for i := 0; i < 20; i++ {
+			time.Sleep(50 * time.Millisecond)
+			if findDaemonPID() == 0 {
+				return
+			}
+		}
+	}
 }
 
 func daemonServiceStatusWithTimeout(timeout time.Duration) (running bool, pid int, err error) {
@@ -245,4 +296,24 @@ func findDaemonPID() int {
 	output, _ := cmd.Output()
 	pid, _ := strconv.Atoi(strings.TrimSpace(string(output)))
 	return pid
+}
+
+// purgeServiceFromLaunchd removes all traces of the daemon from launchd and
+// kills any orphaned process. This is necessary because launchd can enter an
+// inconsistent state where bootstrap fails with "Bad request" when the label
+// is partially registered from a previous load/unload cycle — for example,
+// when a deprecated `launchctl load` was used instead of `bootstrap`, or when
+// the process crashed without a clean `bootout`. Calling this before any
+// bootstrap call guarantees we start from a known-clean state.
+func purgeServiceFromLaunchd() {
+	uid := os.Getuid()
+
+	// Fire all removal variants — they are order-independent and each is a
+	// no-op if the service isn't registered in that domain.
+	_ = exec.Command("launchctl", "bootout", fmt.Sprintf("gui/%d/%s", uid, plistLabel)).Run()
+	_ = exec.Command("launchctl", "remove", plistLabel).Run()
+	_ = exec.Command("launchctl", "unload", plistPath()).Run()
+
+	// Kill any process that survived the launchd removal (orphaned daemon).
+	killDaemonProcess()
 }

--- a/cmd/nixis/setup_darwin.go
+++ b/cmd/nixis/setup_darwin.go
@@ -4,12 +4,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const plistLabel = "com.nixis.daemon"
@@ -20,6 +22,11 @@ func plistPath() string {
 }
 
 func installDaemonService(homeDir, policyDir string, yes bool) error {
+	if !filepath.IsAbs(policyDir) {
+		if abs, err := filepath.Abs(policyDir); err == nil {
+			policyDir = abs
+		}
+	}
 	nixisDir := filepath.Join(homeDir, ".nixis")
 	daemonBin := filepath.Join(nixisDir, "nixis-daemon")
 	logPath := filepath.Join(nixisDir, "daemon.log")
@@ -175,4 +182,67 @@ func stopDaemon() error {
 		}
 	}
 	return nil
+}
+
+func stopDaemonWithTimeout(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "launchctl", "bootout", fmt.Sprintf("gui/%d/%s", os.Getuid(), plistLabel))
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("launchctl timed out after %v (service may be stuck)", timeout)
+	}
+	if err != nil {
+		cmd2 := exec.CommandContext(ctx, "launchctl", "unload", plistPath())
+		if output2, err2 := cmd2.CombinedOutput(); err2 != nil {
+			return fmt.Errorf("stop daemon: %w (%s; %s)", err2,
+				strings.TrimSpace(string(output2)), strings.TrimSpace(string(output)))
+		}
+	}
+	return nil
+}
+
+func daemonServiceStatusWithTimeout(timeout time.Duration) (running bool, pid int, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "launchctl", "list", plistLabel)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return false, 0, fmt.Errorf("launchctl timed out — service may be corrupt")
+	}
+	if err != nil {
+		return false, 0, nil
+	}
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[2] == plistLabel {
+			if fields[0] != "-" {
+				p, _ := strconv.Atoi(fields[0])
+				return true, p, nil
+			}
+			return false, 0, nil
+		}
+	}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "\"PID\"") || strings.HasPrefix(trimmed, "\"pid\"") {
+			parts := strings.SplitN(trimmed, "=", 2)
+			if len(parts) == 2 {
+				val := strings.TrimSpace(strings.TrimRight(parts[1], ";"))
+				p, _ := strconv.Atoi(val)
+				if p > 0 {
+					return true, p, nil
+				}
+			}
+		}
+	}
+	return false, 0, nil
+}
+
+func findDaemonPID() int {
+	cmd := exec.Command("pgrep", "-f", "nixis-daemon")
+	output, _ := cmd.Output()
+	pid, _ := strconv.Atoi(strings.TrimSpace(string(output)))
+	return pid
 }

--- a/cmd/nixis/setup_linux.go
+++ b/cmd/nixis/setup_linux.go
@@ -4,12 +4,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const systemdServiceName = "nixis-daemon.service"
@@ -20,6 +22,11 @@ func systemdUnitPath() string {
 }
 
 func installDaemonService(homeDir, policyDir string, yes bool) error {
+	if !filepath.IsAbs(policyDir) {
+		if abs, err := filepath.Abs(policyDir); err == nil {
+			policyDir = abs
+		}
+	}
 	nixisDir := filepath.Join(homeDir, ".nixis")
 	daemonBin := filepath.Join(nixisDir, "nixis-daemon")
 	socketPath := "/tmp/nixis.sock"
@@ -128,4 +135,54 @@ func stopDaemon() error {
 		return fmt.Errorf("stop daemon: %w (%s)", err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+func stopDaemonWithTimeout(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "systemctl", "--user", "stop", systemdServiceName)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("systemctl timed out after %v (service may be stuck)", timeout)
+	}
+	if err != nil {
+		return fmt.Errorf("stop daemon: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func daemonServiceStatusWithTimeout(timeout time.Duration) (running bool, pid int, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "systemctl", "--user", "show", systemdServiceName,
+		"--property=ActiveState,MainPID")
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return false, 0, fmt.Errorf("systemctl timed out — service may be corrupt")
+	}
+	if err != nil {
+		return false, 0, nil
+	}
+
+	var active string
+	var mainPID int
+	for _, line := range strings.Split(string(output), "\n") {
+		if strings.HasPrefix(line, "ActiveState=") {
+			active = strings.TrimPrefix(line, "ActiveState=")
+		}
+		if strings.HasPrefix(line, "MainPID=") {
+			val := strings.TrimPrefix(line, "MainPID=")
+			mainPID, _ = strconv.Atoi(strings.TrimSpace(val))
+		}
+	}
+
+	isRunning := active == "active"
+	return isRunning, mainPID, nil
+}
+
+func findDaemonPID() int {
+	cmd := exec.Command("pgrep", "-f", "nixis-daemon")
+	output, _ := cmd.Output()
+	pid, _ := strconv.Atoi(strings.TrimSpace(string(output)))
+	return pid
 }

--- a/cmd/nixis/setup_test.go
+++ b/cmd/nixis/setup_test.go
@@ -66,3 +66,216 @@ func TestCopyFile_CreatesNewDst(t *testing.T) {
 		t.Fatalf("dst content = %q, want %q", got, "hello")
 	}
 }
+
+func TestCopyFile_AtomicRename_NoTmpLeftOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst, 0o755); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	// .tmp file should not exist after successful copy
+	tmpFile := dst + ".tmp"
+	if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
+		t.Fatalf("tmp file %s should not exist after successful copy", tmpFile)
+	}
+}
+
+func TestCopyFile_PreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("exec"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst, 0o755); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check executable bit is set
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("dst mode %v does not have executable bit set", info.Mode().Perm())
+	}
+}
+
+func TestCopyFile_SameInode_Symlink(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "real")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(src, []byte("content"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(src, link); err != nil {
+		t.Fatal(err)
+	}
+	// Copying real → link (same inode) should be a no-op
+	if err := copyFile(src, link, 0o755); err != nil {
+		t.Fatalf("copyFile symlink same file: %v", err)
+	}
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "content" {
+		t.Fatalf("content changed: %q", got)
+	}
+}
+
+func TestFindBinary_BinDir(t *testing.T) {
+	dir := t.TempDir()
+	// Resolve symlinks for macOS where /var → /private/var
+	dir, _ = filepath.EvalSymlinks(dir)
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binPath := filepath.Join(binDir, "test-tool")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findBinary("test-tool")
+	if got == "" {
+		t.Fatal("findBinary returned empty, expected bin/test-tool")
+	}
+	expected := filepath.Join(dir, "bin", "test-tool")
+	if got != expected {
+		t.Fatalf("findBinary = %q, want %q", got, expected)
+	}
+}
+
+func TestFindBinary_CurrentDir(t *testing.T) {
+	dir := t.TempDir()
+	dir, _ = filepath.EvalSymlinks(dir)
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	toolPath := filepath.Join(dir, "my-binary")
+	if err := os.WriteFile(toolPath, []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findBinary("my-binary")
+	if got == "" {
+		t.Fatal("findBinary returned empty, expected ./my-binary")
+	}
+	expected := filepath.Join(dir, "my-binary")
+	if got != expected {
+		t.Fatalf("findBinary = %q, want %q", got, expected)
+	}
+}
+
+func TestFindBinary_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findBinary("nonexistent-tool-xyz-12345")
+	if got != "" {
+		t.Fatalf("findBinary for nonexistent tool returned %q, want empty", got)
+	}
+}
+
+// TestRemoveNixisLines exercises the shell-config cleanup logic used by
+// 'nixis uninstall'. Each sub-test mirrors a real scenario.
+func TestRemoveNixisLines(t *testing.T) {
+	write := func(t *testing.T, content string) string {
+		t.Helper()
+		f, err := os.CreateTemp(t.TempDir(), "shellrc")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString(content); err != nil {
+			t.Fatal(err)
+		}
+		_ = f.Close()
+		return f.Name()
+	}
+	read := func(t *testing.T, path string) string {
+		t.Helper()
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+
+	t.Run("removes_marker_export_and_preceding_blank_line", func(t *testing.T) {
+		// Exactly what install.sh appends: \n# Nixis\nexport PATH=...\n
+		input := "export FOO=bar\n\n# Nixis\nexport PATH=\"/home/user/.nixis:$PATH\"\n"
+		want := "export FOO=bar\n"
+		path := write(t, input)
+		if !removeNixisLines(path) {
+			t.Fatal("removeNixisLines reported no modification")
+		}
+		if got := read(t, path); got != want {
+			t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+		}
+	})
+
+	t.Run("removes_fish_add_path_and_preceding_blank_line", func(t *testing.T) {
+		input := "set -x FOO bar\n\n# Nixis\nfish_add_path /home/user/.nixis\n"
+		want := "set -x FOO bar\n"
+		path := write(t, input)
+		if !removeNixisLines(path) {
+			t.Fatal("removeNixisLines reported no modification")
+		}
+		if got := read(t, path); got != want {
+			t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+		}
+	})
+
+	t.Run("no_preceding_blank_line_still_removes_block", func(t *testing.T) {
+		// Block at start of file with no preceding blank line.
+		input := "# Nixis\nexport PATH=\"/home/user/.nixis:$PATH\"\nexport BAR=baz\n"
+		want := "export BAR=baz\n"
+		path := write(t, input)
+		if !removeNixisLines(path) {
+			t.Fatal("removeNixisLines reported no modification")
+		}
+		if got := read(t, path); got != want {
+			t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+		}
+	})
+
+	t.Run("no_nixis_block_is_noop", func(t *testing.T) {
+		input := "export FOO=bar\nexport BAZ=qux\n"
+		path := write(t, input)
+		if removeNixisLines(path) {
+			t.Fatal("removeNixisLines reported modification on file with no Nixis block")
+		}
+		if got := read(t, path); got != input {
+			t.Fatalf("file was modified: got %q, want %q", got, input)
+		}
+	})
+
+	t.Run("preserves_rest_of_file_intact", func(t *testing.T) {
+		input := "# other config\nexport EDITOR=vim\n\n# Nixis\nexport PATH=\"/home/user/.nixis:$PATH\"\n\n# more config\nexport TERM=xterm\n"
+		want := "# other config\nexport EDITOR=vim\n\n# more config\nexport TERM=xterm\n"
+		path := write(t, input)
+		if !removeNixisLines(path) {
+			t.Fatal("removeNixisLines reported no modification")
+		}
+		if got := read(t, path); got != want {
+			t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+		}
+	})
+}

--- a/cmd/nixis/setup_test.go
+++ b/cmd/nixis/setup_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyFile_SameFile_NoError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "binary")
+	if err := os.WriteFile(path, []byte("content"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Copying a file onto itself must be a no-op, not an error.
+	if err := copyFile(path, path, 0o755); err != nil {
+		t.Fatalf("copyFile same src/dst: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "content" {
+		t.Fatalf("file content changed: %q", got)
+	}
+}
+
+func TestCopyFile_UnlinksExistingDst(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst, 0o755); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("dst content = %q, want %q", got, "new")
+	}
+}
+
+func TestCopyFile_CreatesNewDst(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst, 0o644); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("dst content = %q, want %q", got, "hello")
+	}
+}

--- a/cmd/nixis/uninstall.go
+++ b/cmd/nixis/uninstall.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	uninstallYes   bool
+	uninstallForce bool
+)
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Completely remove Nixis from this machine",
+	Long: `Removes all Nixis components: stops daemon, removes service,
+unhooks from Claude Code/Cursor, deletes policies, removes PATH entry,
+and cleans up ~/.nixis/.
+
+This is the inverse of 'nixis setup'. Run it manually — AI agents
+cannot execute this command (Nixis blocks self-removal by policy).
+
+If this command hangs, use --force to bypass service management:
+  nixis uninstall --force --yes
+
+Manual recovery (if even --force hangs):
+  pgrep -f nixis | xargs kill -9 2>/dev/null
+  rm -f ~/Library/LaunchAgents/com.nixis.daemon.plist
+  rm -rf ~/.nixis && rm -f /tmp/nixis.sock`,
+	RunE: runUninstallCmd,
+}
+
+func init() {
+	uninstallCmd.Flags().BoolVarP(&uninstallYes, "yes", "y", false, "Skip confirmation prompt")
+	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "Skip service management (use when launchctl/systemctl is stuck)")
+}
+
+func runUninstallCmd(cmd *cobra.Command, _ []string) error {
+	w := cmd.OutOrStdout()
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	nixisDir := filepath.Join(homeDir, ".nixis")
+
+	fmt.Fprintln(w, "Nixis Uninstall")
+	fmt.Fprintln(w, "===============")
+	fmt.Fprintln(w)
+
+	// Show what will be removed
+	fmt.Fprintln(w, "This will remove:")
+	fmt.Fprintf(w, "  • Daemon service and process\n")
+	fmt.Fprintf(w, "  • Hook from ~/.claude/settings.json\n")
+	fmt.Fprintf(w, "  • PATH entries from shell configs\n")
+	fmt.Fprintf(w, "  • Socket at /tmp/nixis.sock\n")
+	fmt.Fprintf(w, "  • Directory %s\n", nixisDir)
+	fmt.Fprintln(w)
+
+	if !uninstallYes {
+		if !confirm("Proceed with uninstall?") {
+			fmt.Fprintln(w, "Aborted.")
+			return nil
+		}
+		fmt.Fprintln(w)
+	}
+
+	// Step 1: Stop daemon
+	fmt.Fprintln(w, "[1/6] Stopping daemon...")
+	if uninstallForce {
+		if p := findDaemonPID(); p > 0 {
+			fmt.Fprintf(w, "  Force-killing daemon (PID %d)...\n", p)
+			_ = syscall.Kill(p, syscall.SIGKILL)
+			time.Sleep(500 * time.Millisecond)
+		} else {
+			fmt.Fprintln(w, "  No daemon process found")
+		}
+	} else {
+		if err := stopDaemonWithTimeout(5 * time.Second); err != nil {
+			fmt.Fprintf(w, "  Warning: graceful stop failed (%v), force-killing...\n", err)
+			if p := findDaemonPID(); p > 0 {
+				_ = syscall.Kill(p, syscall.SIGKILL)
+				time.Sleep(500 * time.Millisecond)
+			}
+		} else {
+			fmt.Fprintln(w, "  Daemon stopped")
+		}
+	}
+
+	// Step 2: Remove service definition
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "[2/6] Removing service definition...")
+	if err := uninstallDaemonService(); err != nil {
+		fmt.Fprintf(w, "  Warning: %v\n", err)
+	} else {
+		fmt.Fprintln(w, "  Service removed")
+	}
+
+	// Step 3: Remove hook from settings.json
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "[3/6] Removing hook from settings.json...")
+	if err := unpatchSettingsJSON(w, homeDir); err != nil {
+		fmt.Fprintf(w, "  Warning: %v\n", err)
+	}
+
+	// Step 4: Clean shell configs
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "[4/6] Removing PATH entries from shell configs...")
+	cleanShellConfigs(w, homeDir)
+
+	// Step 5: Remove socket
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "[5/6] Removing socket...")
+	sockPath := "/tmp/nixis.sock"
+	if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(w, "  Warning: could not remove %s: %v\n", sockPath, err)
+	} else {
+		fmt.Fprintf(w, "  Removed %s\n", sockPath)
+	}
+
+	// Step 6: Remove ~/.nixis/
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "[6/6] Removing", nixisDir+"...")
+	if err := os.RemoveAll(nixisDir); err != nil {
+		fmt.Fprintf(w, "  Warning: %v\n", err)
+	} else {
+		fmt.Fprintln(w, "  Removed")
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "✓ Nixis uninstalled successfully.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "To reinstall:")
+	fmt.Fprintln(w, "  git clone https://github.com/mayjain/nixis && cd nixis")
+	fmt.Fprintln(w, "  make build && ./nixis setup")
+	return nil
+}
+
+func cleanShellConfigs(w io.Writer, homeDir string) {
+	configs := []string{
+		filepath.Join(homeDir, ".zshrc"),
+		filepath.Join(homeDir, ".bashrc"),
+		filepath.Join(homeDir, ".profile"),
+		filepath.Join(homeDir, ".config", "fish", "config.fish"),
+	}
+	for _, cfg := range configs {
+		if removed := removeNixisLines(cfg); removed {
+			fmt.Fprintf(w, "  Cleaned %s\n", cfg)
+		}
+	}
+}
+
+func removeNixisLines(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var result []string
+	modified := false
+	skipNext := false
+
+	for i, line := range lines {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if strings.Contains(line, "# Nixis") {
+			// Also remove the blank line that install.sh writes immediately
+			// before the marker (\n# Nixis\n...). If the previous collected
+			// line is blank, trim it.
+			if len(result) > 0 && result[len(result)-1] == "" {
+				result = result[:len(result)-1]
+			}
+			skipNext = true // skip the path/export line that follows
+			modified = true
+			_ = i // suppress unused warning
+			continue
+		}
+		result = append(result, line)
+	}
+
+	if modified {
+		_ = os.WriteFile(path, []byte(strings.Join(result, "\n")), 0o644)
+	}
+	return modified
+}

--- a/install.sh
+++ b/install.sh
@@ -89,11 +89,18 @@ install_binaries() {
         mv -f "${TMPDIR}/extracted/${bin}" "${INSTALL_DIR}/${bin}"
     done
     chmod +x "${INSTALL_DIR}/nixis" "${INSTALL_DIR}/nixis-hook" "${INSTALL_DIR}/nixis-daemon"
+    # Move policies from tarball into install dir
+    if [ -d "${TMPDIR}/extracted/policies" ]; then
+        mkdir -p "${INSTALL_DIR}/policies"
+        cp -r "${TMPDIR}/extracted/policies/." "${INSTALL_DIR}/policies/"
+    fi
 }
 
 run_setup() {
-    info "Configuring (policies + daemon + hook)..."
-    "${INSTALL_DIR}/nixis" setup --yes --skip-binaries
+    info "Configuring (daemon + hook)..."
+    # Policies are already in ${INSTALL_DIR}/policies from the tarball;
+    # pass --policy-dir so setup doesn't look for ./policies in CWD.
+    "${INSTALL_DIR}/nixis" setup --yes --skip-binaries --policy-dir "${INSTALL_DIR}/policies"
 }
 
 # Detect the shell config file to write PATH into.

--- a/install.sh
+++ b/install.sh
@@ -170,7 +170,5 @@ main() {
     run_setup
     print_success
 }
-    print_success
-}
 
 main

--- a/install.sh
+++ b/install.sh
@@ -83,8 +83,17 @@ verify_checksum() {
 install_binaries() {
     info "Installing to ${INSTALL_DIR}..."
     mkdir -p "$INSTALL_DIR"
-    tar -xzf "${TMPDIR}/${TARBALL}" -C "$INSTALL_DIR"
-    chmod +x "${INSTALL_DIR}/nixis" "${INSTALL_DIR}/nixis-hook"
+    mkdir -p "${TMPDIR}/extracted"
+    tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}/extracted"
+    for bin in nixis nixis-hook nixis-daemon; do
+        mv -f "${TMPDIR}/extracted/${bin}" "${INSTALL_DIR}/${bin}"
+    done
+    chmod +x "${INSTALL_DIR}/nixis" "${INSTALL_DIR}/nixis-hook" "${INSTALL_DIR}/nixis-daemon"
+}
+
+run_setup() {
+    info "Configuring (policies + daemon + hook)..."
+    "${INSTALL_DIR}/nixis" setup --yes --skip-binaries
 }
 
 # Detect the shell config file to write PATH into.
@@ -160,6 +169,7 @@ main() {
     verify_checksum
     install_binaries
     add_to_path
+    run_setup
     print_success
 }
 

--- a/install.sh
+++ b/install.sh
@@ -87,20 +87,68 @@ install_binaries() {
     chmod +x "${INSTALL_DIR}/nixis" "${INSTALL_DIR}/nixis-hook"
 }
 
-print_success() {
-    printf "\n\033[1;32m✓ Nixis installed successfully!\033[0m\n\n"
-    printf "  Binaries: %s/nixis, %s/nixis-hook\n" "$INSTALL_DIR" "$INSTALL_DIR"
-    printf "  Version:  %s\n\n" "$VERSION"
-
-    case ":${PATH}:" in
-        *":${INSTALL_DIR}:"*) ;;
-        *)
-            printf "  Add to your PATH:\n"
-            printf "    export PATH=\"%s:\$PATH\"\n\n" "$INSTALL_DIR"
-            ;;
+# Detect the shell config file to write PATH into.
+detect_shell_config() {
+    # Prefer the running shell's rc file; fall back to common defaults.
+    SHELL_NAME=$(basename "${SHELL:-}")
+    case "$SHELL_NAME" in
+        zsh)  SHELL_CONFIG="$HOME/.zshrc" ;;
+        bash) SHELL_CONFIG="${HOME}/.bashrc" ;;
+        fish) SHELL_CONFIG="$HOME/.config/fish/config.fish" ;;
+        *)    SHELL_CONFIG="" ;;
     esac
 
-    printf "  Run 'nixis setup' to configure.\n\n"
+    # Fall back to the first file that already exists.
+    if [ -z "$SHELL_CONFIG" ] || [ ! -f "$SHELL_CONFIG" ]; then
+        for f in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+            if [ -f "$f" ]; then
+                SHELL_CONFIG="$f"
+                break
+            fi
+        done
+    fi
+}
+
+add_to_path() {
+    detect_shell_config
+
+    # Already in PATH — nothing to do.
+    case ":${PATH}:" in
+        *":${INSTALL_DIR}:"*) return ;;
+    esac
+
+    if [ -z "$SHELL_CONFIG" ]; then
+        warn "Could not detect shell config file. Add this manually:"
+        warn "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+        return
+    fi
+
+    # Already written to this config file — skip.
+    if grep -q "${INSTALL_DIR}" "$SHELL_CONFIG" 2>/dev/null; then
+        return
+    fi
+
+    if [ "$SHELL_NAME" = "fish" ]; then
+        printf '\n# Nixis\nfish_add_path %s\n' "$INSTALL_DIR" >> "$SHELL_CONFIG"
+    else
+        printf '\n# Nixis\nexport PATH="%s:$PATH"\n' "$INSTALL_DIR" >> "$SHELL_CONFIG"
+    fi
+
+    info "Added ${INSTALL_DIR} to PATH in ${SHELL_CONFIG}"
+    NEEDS_SOURCE="$SHELL_CONFIG"
+}
+
+print_success() {
+    printf "\n\033[1;32m✓ Nixis installed to %s\033[0m\n\n" "$INSTALL_DIR"
+    printf "  Version: %s\n\n" "$VERSION"
+
+    if [ -n "${NEEDS_SOURCE:-}" ]; then
+        printf "  Reload your shell, then run setup:\n\n"
+        printf "    \033[1msource %s && nixis setup\033[0m\n\n" "$NEEDS_SOURCE"
+    else
+        printf "  Run setup:\n\n"
+        printf "    \033[1mnixis setup\033[0m\n\n"
+    fi
 }
 
 main() {
@@ -111,6 +159,7 @@ main() {
     download
     verify_checksum
     install_binaries
+    add_to_path
     print_success
 }
 

--- a/install.sh
+++ b/install.sh
@@ -155,16 +155,7 @@ add_to_path() {
 }
 
 print_success() {
-    printf "\n\033[1;32m✓ Nixis installed to %s\033[0m\n\n" "$INSTALL_DIR"
-    printf "  Version: %s\n\n" "$VERSION"
-
-    if [ -n "${NEEDS_SOURCE:-}" ]; then
-        printf "  Reload your shell, then run setup:\n\n"
-        printf "    \033[1msource %s && nixis setup\033[0m\n\n" "$NEEDS_SOURCE"
-    else
-        printf "  Run setup:\n\n"
-        printf "    \033[1mnixis setup\033[0m\n\n"
-    fi
+    printf "\n\033[1;32m✓ Nixis %s installed to %s\033[0m\n\n" "$VERSION" "$INSTALL_DIR"
 }
 
 main() {
@@ -175,8 +166,10 @@ main() {
     download
     verify_checksum
     install_binaries
-    add_to_path
+    handle_macos_gatekeeper
     run_setup
+    print_success
+}
     print_success
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -41,7 +41,7 @@ type Daemon struct {
 
 	reloader reload.PolicyReloader // nil until SetReloader is called
 
-	mode modeState
+	mode        modeState
 	evaluations atomic.Int64
 	startTime   time.Time
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mayankjain0141/nixis/internal/delegation"
 	"github.com/mayankjain0141/nixis/internal/ifc"
 	"github.com/mayankjain0141/nixis/internal/otel"
+	"github.com/mayankjain0141/nixis/internal/reload"
 	"github.com/mayankjain0141/nixis/internal/stream"
 	"github.com/mayankjain0141/nixis/pkg/nixis"
 )
@@ -38,7 +39,9 @@ type Daemon struct {
 	delegAPI     *DelegationAPI     // nil disables delegation HTTP endpoints
 	taintHistory *ifc.TaintHistory  // nil disables taint history pruning
 
-	mode        modeState
+	reloader reload.PolicyReloader // nil until SetReloader is called
+
+	mode modeState
 	evaluations atomic.Int64
 	startTime   time.Time
 
@@ -258,6 +261,30 @@ func (d *Daemon) SetTaintHistory(h *ifc.TaintHistory) {
 	d.taintHistory = h
 }
 
+// SetReloader wires a PolicyReloader so the /reload HTTP endpoint can trigger
+// a policy re-parse and engine reload on demand.
+func (d *Daemon) SetReloader(r reload.PolicyReloader) {
+	d.reloader = r
+}
+
+// handleReload triggers a synchronous policy reload via the wired PolicyReloader.
+func (d *Daemon) handleReload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	if d.reloader == nil {
+		http.Error(w, "no reloader configured", http.StatusServiceUnavailable)
+		return
+	}
+	if err := d.reloader.Reload(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("{\"status\":\"reloaded\"}\n"))
+}
+
 // runMaintenanceLoop runs periodic cleanup tasks:
 // - Prune expired standing rules from all sessions every 5 minutes
 // - Prune old taint history records older than 7 days every hour
@@ -309,6 +336,7 @@ type Check struct {
 func (d *Daemon) serveHealthz(ctx context.Context) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", d.handleHealthz)
+	mux.HandleFunc("/reload", d.handleReload)
 	if d.delegAPI != nil {
 		d.delegAPI.RegisterRoutes(mux)
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3,7 +3,9 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -629,5 +631,186 @@ func TestDaemon_ModeReadOnly_DeniesRequests(t *testing.T) {
 	}
 	if resp.Decision.Reason != "daemon in read_only mode" {
 		t.Errorf("unexpected reason: %q", resp.Decision.Reason)
+	}
+}
+
+// --- /reload endpoint tests ---
+
+type stubReloader struct {
+	mu      sync.Mutex
+	err     error
+	called  int
+}
+
+func (s *stubReloader) Reload() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.called++
+	return s.err
+}
+
+func TestHandleReload_POST_Success(t *testing.T) {
+	_, ready, healthzAddr := startDaemonWithTap(t, allowEngine{}, nil, nil)
+	waitReady(t, ready)
+
+	// Wire reloader — need direct access to daemon's reloader field.
+	// Use a fresh daemon with reloader for this test.
+	socketPath := testSocketPath()
+	healthzAddr2 := testHealthzAddr()
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	cfg := Config{SocketPath: socketPath, HealthzAddr: healthzAddr2}
+	w, auditCancel, auditDone := newTestAuditWriter(t)
+	d := New(cfg, allowEngine{}, w, nil, nil)
+	d.SetAuditContext(auditCancel, auditDone)
+
+	sr := &stubReloader{}
+	d.SetReloader(sr)
+
+	ready2 := make(chan struct{})
+	d.setReadyCh(ready2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runDone:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitReady(t, ready2)
+
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	var resp *http.Response
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var err error
+		resp, err = client.Post("http://"+healthzAddr2+"/reload", "", nil)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if resp == nil {
+		t.Fatal("reload endpoint never became available")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "{\"status\":\"reloaded\"}\n" {
+		t.Errorf("unexpected body: %q", body)
+	}
+	sr.mu.Lock()
+	if sr.called != 1 {
+		t.Errorf("expected reloader called once, got %d", sr.called)
+	}
+	sr.mu.Unlock()
+
+	_ = healthzAddr // suppress unused from first startDaemonWithTap
+}
+
+func TestHandleReload_GET_MethodNotAllowed(t *testing.T) {
+	socketPath := testSocketPath()
+	healthzAddr := testHealthzAddr()
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	cfg := Config{SocketPath: socketPath, HealthzAddr: healthzAddr}
+	w, auditCancel, auditDone := newTestAuditWriter(t)
+	d := New(cfg, allowEngine{}, w, nil, nil)
+	d.SetAuditContext(auditCancel, auditDone)
+	d.SetReloader(&stubReloader{})
+
+	ready := make(chan struct{})
+	d.setReadyCh(ready)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runDone:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitReady(t, ready)
+
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	var resp *http.Response
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var err error
+		resp, err = client.Get("http://" + healthzAddr + "/reload")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if resp == nil {
+		t.Fatal("reload endpoint never became available")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleReload_Error_Returns500(t *testing.T) {
+	socketPath := testSocketPath()
+	healthzAddr := testHealthzAddr()
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+	cfg := Config{SocketPath: socketPath, HealthzAddr: healthzAddr}
+	w, auditCancel, auditDone := newTestAuditWriter(t)
+	d := New(cfg, allowEngine{}, w, nil, nil)
+	d.SetAuditContext(auditCancel, auditDone)
+	d.SetReloader(&stubReloader{err: errors.New("parse error: invalid yaml")})
+
+	ready := make(chan struct{})
+	d.setReadyCh(ready)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runDone:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitReady(t, ready)
+
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	var resp *http.Response
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var err error
+		resp, err = client.Post("http://"+healthzAddr+"/reload", "", nil)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if resp == nil {
+		t.Fatal("reload endpoint never became available")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "parse error: invalid yaml\n" {
+		t.Errorf("unexpected error body: %q", body)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -637,9 +637,9 @@ func TestDaemon_ModeReadOnly_DeniesRequests(t *testing.T) {
 // --- /reload endpoint tests ---
 
 type stubReloader struct {
-	mu      sync.Mutex
-	err     error
-	called  int
+	mu     sync.Mutex
+	err    error
+	called int
 }
 
 func (s *stubReloader) Reload() error {

--- a/internal/reload/watcher.go
+++ b/internal/reload/watcher.go
@@ -3,6 +3,7 @@ package reload
 
 import (
 	"context"
+	"io/fs"
 	"log/slog"
 	"path/filepath"
 	"sync/atomic"
@@ -55,7 +56,12 @@ func (r *ReloadWatcher) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := watcher.Add(r.policyDir); err != nil {
+	if err := filepath.WalkDir(r.policyDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil
+		}
+		return watcher.Add(path)
+	}); err != nil {
 		if cerr := watcher.Close(); cerr != nil {
 			slog.Error("fsnotify watcher close error", "err", cerr)
 		}

--- a/internal/reload/watcher_test.go
+++ b/internal/reload/watcher_test.go
@@ -210,3 +210,28 @@ func TestReload_MetricsIncrement(t *testing.T) {
 		t.Errorf("ReloadSuccessTotal: expected delta 1; got %d", got)
 	}
 }
+
+func TestReload_SubdirectoryFileChange(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "builtin")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	mock := &mockReloader{}
+	cancel, done := startWatcher(t, dir, mock)
+	time.Sleep(50 * time.Millisecond)
+
+	// Write a YAML file in the subdirectory — should trigger reload.
+	if err := os.WriteFile(filepath.Join(subdir, "deny-rm.yaml"), []byte("action: deny"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	cancel()
+	<-done
+
+	if count := mock.reloadCount(); count != 1 {
+		t.Errorf("expected 1 reload from subdirectory change; got %d", count)
+	}
+}

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Git pre-push hook — runs the same checks as GitHub CI before every push.
+# Install with: make install-hooks
+
+set -e
+
+echo "==> Pre-push: running CI checks (make ci)..."
+echo "    (skip with: git push --no-verify)"
+echo ""
+
+make ci


### PR DESCRIPTION
## Summary

Complete overhaul of the Nixis installer, addressing a collection of bugs that made installation unreliable — especially on fresh machines and Linux.

Fixes #3 

### Critical bug fixes

- **ETXTBSY on Linux** (`text file busy`): `nixis setup` after `curl | sh` tried to copy a running binary onto itself. Fixed via atomic write-to-`.tmp` + `os.Rename` throughout `copyFile`. Same fix applied to `install.sh` which was `tar`-extracting over a running daemon on upgrade.
- **Zombie processes** (`nixis doctor` / `nixis setup --uninstall` hung indefinitely): All `launchctl`/`systemctl` calls now use `exec.CommandContext` with timeouts + SIGKILL fallback. `nixis uninstall --force` bypasses service management entirely for recovery.
- **launchd ghost registration** (`Bad request` on macOS reinstall): `launchctl bootstrap` silently returns 0 but leaves stale label state across install cycles. Added `purgeServiceFromLaunchd()` which fires all removal variants before every bootstrap.
- **Policy path missing from curl install**: `run_setup()` called `nixis setup --yes --skip-binaries` without `--policy-dir`, causing `set -euo pipefail` to abort when `./policies` didn't exist in the user's CWD. Fixed by bundling `policies/**` in the goreleaser archive and extracting to `${INSTALL_DIR}/policies/` before setup.
- **Daemon race condition**: `make install` ran `nixis doctor` immediately after `launchctl bootstrap` (which returns before the process is ready). Added `waitForDaemon()` polling loop (healthz + socket, up to 10s).
- **`imported/` policies silently skipped**: `copyPolicies` only recursed one level deep, missing `policies/imported/<source>/*.yaml`. Replaced hand-rolled loop with `filepath.WalkDir`.

### New commands

- `nixis reload` — POST to daemon `/reload` endpoint for instant policy refresh without restart
- `nixis uninstall` — top-level command (not buried in `setup --uninstall`), cleans daemon, service, hook, PATH entries from shell configs, socket, and `~/.nixis/`. `--force` skips launchctl for recovery.

### Daemon improvements

- `/reload` HTTP endpoint on port 9091 (required for `nixis reload`)
- Recursive `fsnotify` subdirectory watching via `filepath.WalkDir` so changes in `policies/builtin/` actually trigger hot reload
- Actionable `EADDRINUSE` error message with `lsof` hint

### Build/Makefile

- `make install`: idempotent — stops daemon, rm, cp, setup
- `make dev-install`: first-time clone setup (test-keys + npm install + install), prints PATH hint
- `make update-policies`: rsync + `nixis reload`
- `preflight`/`preflight-node`: Go ≥ 1.25, Node ≥ 26, sudo guard

### Security

- Removed `xattr -d com.apple.quarantine` from `install.sh` (triggered EDR behavioral detection)
- Removed goreleaser ad-hoc codesign hooks (no value, potential EDR flag)

## Test plan

- [ ] `make dev-install` from fresh clone (Scenario 1)
- [ ] `make install` while daemon running — daemon restarts, `nixis doctor` HEALTHY (Scenario 2)
- [ ] `make update-policies` with canary policy — DENY, remove, ALLOW (Scenario 3)
- [ ] `nixis reload` adds/removes policy dynamically (Scenario 12)
- [ ] `nixis uninstall --yes` cleans everything including PATH from `.zshrc` (Scenario 5, run manually)
- [ ] `nixis doctor` completes in <5s with no zombie processes
- [ ] `go test ./... -race` passes